### PR TITLE
Support for JDK 1.8. Fixed minor issues related to exception handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>0.1-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -65,6 +65,12 @@
             <groupId>org.duckdb</groupId>
             <artifactId>duckdb_jdbc</artifactId>
             <version>0.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.2.7</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.networknt</groupId>
@@ -166,7 +172,8 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.36.0</version>
+                <!-- To support JDK 1.8 -->
+                <version>2.30.0</version>
                 <configuration>
                     <java>
                         <includes>
@@ -186,6 +193,7 @@
                             <file>${project.basedir}/src/main/resources/license-header</file>
                         </licenseHeader>
                     </java>
+                    <!--
                     <json>
                         <includes>
                             <include>src/main/resources/**/*.json</include>
@@ -193,7 +201,8 @@
                         <jackson>
                             <version>2.14.2</version>
                         </jackson>
-                    </json>
+			        </json>
+		            -->
                     <sql>
                         <includes>
                             <include>src/main/resources/**/*.sql</include>

--- a/src/main/java/com/microsoft/lst_bench/common/LSTBenchmarkExecutor.java
+++ b/src/main/java/com/microsoft/lst_bench/common/LSTBenchmarkExecutor.java
@@ -115,7 +115,7 @@ public class LSTBenchmarkExecutor extends BenchmarkRunnable {
             checkResults(executor.invokeAll(threads));
             eventInfo = writePhaseEvent(phaseStartTime, phase.getId(), Status.SUCCESS);
           } catch (Exception e) {
-            LOGGER.error("Exception executing phase: " + phase.getId());
+            LOGGER.error("Exception executing phase: " + phase.getId(), e);
             writePhaseEvent(phaseStartTime, phase.getId(), Status.FAILURE);
             throw e;
           }
@@ -136,7 +136,7 @@ public class LSTBenchmarkExecutor extends BenchmarkRunnable {
             Status.SUCCESS,
             new ObjectMapper().writeValueAsString(experimentMetadata));
       } catch (Exception e) {
-        LOGGER.error("Exception executing experiment: " + config.getId());
+        LOGGER.error("Exception executing experiment: " + config.getId(), e);
         writeExperimentEvent(
             repetitionStartTime,
             config.getId(),
@@ -232,14 +232,14 @@ public class LSTBenchmarkExecutor extends BenchmarkRunnable {
             Map<String, Object> values = getRuntimeParameterValues(task);
             executeTask(connection, task, values);
           } catch (Exception e) {
-            LOGGER.error("Exception executing task: " + task.getId());
+            LOGGER.error("Exception executing task: " + task.getId(), e);
             writeTaskEvent(taskStartTime, task.getId(), Status.FAILURE);
             throw e;
           }
           writeTaskEvent(taskStartTime, task.getId(), Status.SUCCESS);
         }
       } catch (Exception e) {
-        LOGGER.error("Exception executing session: " + session.getId());
+        LOGGER.error("Exception executing session: " + session.getId(), e);
         writeSessionEvent(sessionStartTime, session.getId(), Status.FAILURE);
         throw e;
       }
@@ -255,8 +255,9 @@ public class LSTBenchmarkExecutor extends BenchmarkRunnable {
           for (StatementExec statement : file.getStatements()) {
             Instant statementStartTime = Instant.now();
             try (Statement s = connection.createStatement()) {
-              boolean hasResults =
-                  s.execute(StringUtils.replaceParameters(statement, values).getStatement());
+              String sqlStr = StringUtils.replaceParameters(statement, values).getStatement();
+              LOGGER.debug("Executing query: {}", sqlStr);
+              boolean hasResults = s.execute(sqlStr);
               if (hasResults) {
                 ResultSet rs = s.getResultSet();
                 while (rs.next()) {
@@ -264,14 +265,14 @@ public class LSTBenchmarkExecutor extends BenchmarkRunnable {
                 }
               }
             } catch (Exception e) {
-              LOGGER.error("Exception executing statement: " + statement.getId());
+              LOGGER.error("Exception executing statement: " + statement.getId(), e);
               writeStatementEvent(statementStartTime, statement.getId(), Status.FAILURE);
               throw e;
             }
             writeStatementEvent(statementStartTime, statement.getId(), Status.SUCCESS);
           }
         } catch (Exception e) {
-          LOGGER.error("Exception executing file: " + file.getId());
+          LOGGER.error("Exception executing file: " + file.getId(), e);
           writeFileEvent(fileStartTime, file.getId(), Status.FAILURE);
           throw e;
         }

--- a/src/main/java/com/microsoft/lst_bench/sql/ConnectionManager.java
+++ b/src/main/java/com/microsoft/lst_bench/sql/ConnectionManager.java
@@ -21,10 +21,13 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Simple JDBC connection manager. */
 public class ConnectionManager {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectionManager.class);
   private final String url;
 
   @Nullable private final String username;
@@ -38,6 +41,7 @@ public class ConnectionManager {
   }
 
   public Connection createConnection() throws SQLException {
+    LOG.info("Creating connection: url: {}, username:{}", url, username);
     if (StringUtils.isEmpty(username)) {
       return DriverManager.getConnection(url);
     } else {
@@ -47,6 +51,7 @@ public class ConnectionManager {
 
   public static ConnectionManager from(ConnectionConfig connectionConfig) {
     try {
+      LOG.info("Loading driver: {}", connectionConfig.getDriver());
       Class.forName(connectionConfig.getDriver());
     } catch (ClassNotFoundException e) {
       throw new IllegalArgumentException(


### PR DESCRIPTION
- Support for JDK 1.8. Lot of engines support 1.8
- Adding HSQL db in case some nodes face issues related to duckdb native libs
- Fixed spotless version to support JDK 1.8
- Fixed minor issues related to exception handling.