### PR TITLE
Add runid to track experiment runs and timeline

### DIFF
--- a/src/main/java/com/microsoft/lst_bench/telemetry/EventInfo.java
+++ b/src/main/java/com/microsoft/lst_bench/telemetry/EventInfo.java
@@ -16,6 +16,7 @@
 package com.microsoft.lst_bench.telemetry;
 
 import java.time.Instant;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
@@ -23,6 +24,12 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Value.Style(jdkOnly = true, allParameters = true, defaults = @Value.Immutable(builder = false))
 public interface EventInfo {
+  /**
+   * Returns the unique identifier for the experiment run. This identifier helps in distinguishing
+   * events of one experiment run from another.
+   */
+  UUID getExperimentRunId();
+
   Instant getStartTime();
 
   Instant getEndTime();

--- a/src/main/java/com/microsoft/lst_bench/telemetry/JDBCTelemetryRegistry.java
+++ b/src/main/java/com/microsoft/lst_bench/telemetry/JDBCTelemetryRegistry.java
@@ -94,7 +94,7 @@ public class JDBCTelemetryRegistry {
                   o ->
                       String.join(
                           ",",
-                          o.getExperimentRunId().toString(),
+                          StringUtils.quote(o.getExperimentRunId().toString()),
                           StringUtils.quote(o.getStartTime().toString()),
                           StringUtils.quote(o.getEndTime().toString()),
                           StringUtils.quote(o.getEventId()),

--- a/src/main/java/com/microsoft/lst_bench/telemetry/JDBCTelemetryRegistry.java
+++ b/src/main/java/com/microsoft/lst_bench/telemetry/JDBCTelemetryRegistry.java
@@ -94,6 +94,7 @@ public class JDBCTelemetryRegistry {
                   o ->
                       String.join(
                           ",",
+                          o.getExperimentRunId().toString(),
                           StringUtils.quote(o.getStartTime().toString()),
                           StringUtils.quote(o.getEndTime().toString()),
                           StringUtils.quote(o.getEventId()),

--- a/src/main/resources/scripts/logging/duckdb/ddl.sql
+++ b/src/main/resources/scripts/logging/duckdb/ddl.sql
@@ -1,6 +1,7 @@
 CREATE
     TABLE
         IF NOT EXISTS experiment_telemetry(
+            run_id STRING,
             event_start_time STRING,
             event_end_time STRING,
             event_id STRING,


### PR DESCRIPTION
Fixes #46

This change introduces a new field called "experiment run id" of the UUID data type. Its purpose is to provide a unique identifier for each experiment run. Consequently, every timeline event produced by the experiment run is labeled with this UUID to streamline the process of monitoring and analyzing the events. 
Note: this change to the timeline event schema could be a breaking change for some scripts (as the timeline event schema has changed).