### PR TITLE
Fix event persistence error handling

### DIFF
--- a/src/main/java/com/microsoft/lst_bench/telemetry/EventException.java
+++ b/src/main/java/com/microsoft/lst_bench/telemetry/EventException.java
@@ -15,20 +15,14 @@
  */
 package com.microsoft.lst_bench.telemetry;
 
-public class TelemetryHook extends Thread {
+/** An exception related to management of {@link EventInfo}. */
+public class EventException extends Exception {
 
-  private final JDBCTelemetryRegistry telemetryRegistry;
-
-  public TelemetryHook(JDBCTelemetryRegistry telemetryRegistry) {
-    this.telemetryRegistry = telemetryRegistry;
+  public EventException(Exception cause) {
+    super(cause);
   }
 
-  @Override
-  public void run() {
-    try {
-      telemetryRegistry.flush();
-    } catch (EventException e) {
-      throw new RuntimeException(e);
-    }
+  public EventException(String message) {
+    super(message);
   }
 }

--- a/src/main/java/com/microsoft/lst_bench/telemetry/JDBCTelemetryRegistry.java
+++ b/src/main/java/com/microsoft/lst_bench/telemetry/JDBCTelemetryRegistry.java
@@ -82,7 +82,7 @@ public class JDBCTelemetryRegistry {
   }
 
   /** Flushes the events to the database. */
-  public void flush() {
+  public void flush() throws EventException {
     LOGGER.info("Flushing events to database...");
     try (Connection connection = connectionManager.createConnection();
         Statement statement = connection.createStatement()) {
@@ -109,7 +109,8 @@ public class JDBCTelemetryRegistry {
       eventsStream = Collections.synchronizedList(new ArrayList<>());
       LOGGER.info("Events flushed to database.");
     } catch (SQLException e) {
-      LOGGER.error("Error while flushing events to database", e);
+      LOGGER.error("Error while flushing events to database");
+      throw new EventException(e);
     }
   }
 }

--- a/src/main/java/com/microsoft/lst_bench/telemetry/JDBCTelemetryRegistry.java
+++ b/src/main/java/com/microsoft/lst_bench/telemetry/JDBCTelemetryRegistry.java
@@ -109,7 +109,6 @@ public class JDBCTelemetryRegistry {
       eventsStream = Collections.synchronizedList(new ArrayList<>());
       LOGGER.info("Events flushed to database.");
     } catch (SQLException e) {
-      LOGGER.error("Error while flushing events to database");
       throw new EventException(e);
     }
   }


### PR DESCRIPTION
This commit fixes a bug in the error handling logic while attempting to flush event info objects. Currently, if an error occurs, the exception is caught, logged, and ignored. It is not passed to the caller. As a result the processing continues without completing the action of persisting the benchmark events.

The fix throws a custom error corresponding to Events and lets the caller decide if the processing should continue. As of now the error should result in termination of the workload or fail unit tests.

Fixes #48 