### PR TITLE
Make the clusterPlots notebook consistent with telemetry schema

### DIFF
--- a/metrics/notebooks/clusterPlots.ipynb
+++ b/metrics/notebooks/clusterPlots.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,14 +43,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "# --- Data manipulations --- #\n",
     "\n",
     "# Retrieve relevant data from duckdb.\n",
-    "EXP_DATA = retrieve_experiment_df(con, EXPERIMENT_ID, EXPERIMENT_START_TIME)\n",
+    "EXP_DATA = pd.DataFrame()\n",
+    "for idx, id in enumerate(EXPERIMENT_ID):\n",
+    "    EXP_DATA = pd.concat([EXP_DATA, retrieve_experiment_df(con, id, EXPERIMENT_START_TIME[idx])])\n",
     "\n",
     "# Remove superfluous entries from dataframe.\n",
     "EXP_DATA = filterByEventIds(EXP_DATA, EVENT_IDS)"
@@ -58,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +107,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.6"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
Making the clusterPlots notebook consistent with execTimePlots and storagePlots notebooks. 