### PR TITLE
Update config file paths in tests, fix build

### DIFF
--- a/src/test/java/com/microsoft/lst_bench/common/LSTBenchmarkExecutorTest.java
+++ b/src/test/java/com/microsoft/lst_bench/common/LSTBenchmarkExecutorTest.java
@@ -112,7 +112,7 @@ class LSTBenchmarkExecutorTest {
     TaskLibrary taskLibrary = mapper.readValue(new File(taskLibFile.getFile()), TaskLibrary.class);
 
     URL workloadFile =
-        getClass().getClassLoader().getResource("./config/spark/w_all_tpcds_delta.yaml");
+        getClass().getClassLoader().getResource("./config/spark/w_all_tpcds-delta.yaml");
     Assertions.assertNotNull(workloadFile);
     Workload workload = mapper.readValue(new File(workloadFile.getFile()), Workload.class);
 


### PR DESCRIPTION
In a recent commit, some config files used by unit tests were moved. Coincidentally, the commit which added the failing tests was made in a branch which did not have the commit with the updated paths.