### PR TITLE
Support environment variables in config files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ The configuration files used in LST-Bench are YAML files.
 You can find their schema, which describes the expected structure and properties, [here](src/main/resources/schemas).
 
 Additionally, you can find sample configurations that can serve as guidelines for creating your configurations [here](src/main/resources/config).
+The YAML file can also contain references to environment variable along with default values. The parser will handle the same appropriately. 
+Example:
+```bash
+    parameter_name: ${ENVIRONMENT_VARIABLE:-default_value}
+```
 
 ## Architecture
 

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
+                <configuration>
+                    <environmentVariables>
+                        <DATABASE_PASSWORD>p@ssw0rd0</DATABASE_PASSWORD>
+                    </environmentVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>5.4.0</version>
@@ -196,9 +202,10 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
                 <configuration>
-                    <environmentVariables>
-                        <DATABASE_PASSWORD>p@ssw0rd0</DATABASE_PASSWORD>
-                    </environmentVariables>
+                    <argLine>
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
+                <!--Enable reflective access to change environment variables used by junit-pioneer
+                    in the ParseTest. Documentation:
+                    https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access -->
                 <configuration>
                     <argLine>
                         --add-opens java.base/java.util=ALL-UNNAMED

--- a/src/main/java/com/microsoft/lst_bench/Driver.java
+++ b/src/main/java/com/microsoft/lst_bench/Driver.java
@@ -15,8 +15,6 @@
  */
 package com.microsoft.lst_bench;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.microsoft.lst_bench.client.ConnectionManager;
 import com.microsoft.lst_bench.common.BenchmarkConfig;
 import com.microsoft.lst_bench.common.BenchmarkRunnable;
@@ -30,7 +28,7 @@ import com.microsoft.lst_bench.input.config.ExperimentConfig;
 import com.microsoft.lst_bench.input.config.TelemetryConfig;
 import com.microsoft.lst_bench.telemetry.SQLTelemetryRegistry;
 import com.microsoft.lst_bench.telemetry.TelemetryHook;
-import java.io.File;
+import com.microsoft.lst_bench.util.FileParser;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -106,16 +104,15 @@ public class Driver {
     Validate.notNull(inputTelemetryConfigFile, "Telemetry config file is required.");
 
     // Create Java objects from input files
-    final ObjectMapper mapper = new YAMLMapper();
     final TaskLibrary taskLibrary =
-        mapper.readValue(new File(inputTaskLibraryFile), TaskLibrary.class);
-    final Workload workload = mapper.readValue(new File(inputWorkloadFile), Workload.class);
+        FileParser.createObject(inputTaskLibraryFile, TaskLibrary.class);
+    final Workload workload = FileParser.createObject(inputWorkloadFile, Workload.class);
     final ConnectionsConfig connectionsConfig =
-        mapper.readValue(new File(inputConnectionsConfigFile), ConnectionsConfig.class);
+        FileParser.createObject(inputConnectionsConfigFile, ConnectionsConfig.class);
     final ExperimentConfig experimentConfig =
-        mapper.readValue(new File(inputExperimentConfigFile), ExperimentConfig.class);
+        FileParser.createObject(inputExperimentConfigFile, ExperimentConfig.class);
     final TelemetryConfig telemetryConfig =
-        mapper.readValue(new File(inputTelemetryConfigFile), TelemetryConfig.class);
+        FileParser.createObject(inputTelemetryConfigFile, TelemetryConfig.class);
 
     run(taskLibrary, workload, connectionsConfig, experimentConfig, telemetryConfig);
   }

--- a/src/main/java/com/microsoft/lst_bench/util/FileParser.java
+++ b/src/main/java/com/microsoft/lst_bench/util/FileParser.java
@@ -103,6 +103,10 @@ public class FileParser {
     return values;
   }
 
+  /**
+   * Reads the YAML file and replaces all environment variables (if present). Creates and returns an
+   * object of `objectType` class.
+   */
   public static <T> T createObject(String filePath, Class<T> objectType) throws IOException {
     return yamlMapper.readValue(StringUtils.replaceEnvVars(new File(filePath)), objectType);
   }

--- a/src/main/java/com/microsoft/lst_bench/util/FileParser.java
+++ b/src/main/java/com/microsoft/lst_bench/util/FileParser.java
@@ -15,6 +15,8 @@
  */
 package com.microsoft.lst_bench.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -29,6 +31,8 @@ import java.util.StringTokenizer;
 
 /** Utility class with methods to parse auxiliary files for the benchmark. */
 public class FileParser {
+
+  private static final ObjectMapper yamlMapper = new YAMLMapper();
 
   private FileParser() {
     // Defeat instantiation
@@ -97,5 +101,9 @@ public class FileParser {
       throw new RuntimeException("Cannot read parameter values file: " + file.getAbsolutePath(), e);
     }
     return values;
+  }
+
+  public static <T> T createObject(String filePath, Class<T> objectType) throws IOException {
+    return yamlMapper.readValue(StringUtils.replaceEnvVars(new File(filePath)), objectType);
   }
 }

--- a/src/main/java/com/microsoft/lst_bench/util/StringUtils.java
+++ b/src/main/java/com/microsoft/lst_bench/util/StringUtils.java
@@ -27,9 +27,13 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.text.StringSubstitutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utility class for string operations. */
 public class StringUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StringUtils.class);
 
   private StringUtils() {
     // Defeat instantiation
@@ -80,9 +84,15 @@ public class StringUtils {
             .collect(Collectors.toList()));
   }
 
+  /**
+   * Reads the contents of the `sourceFile` and replaces any environment variables if present. If
+   * the environment variable is not set, the default value is used if specified. All other
+   * parameters are ignored.
+   */
   public static String replaceEnvVars(File sourceFile) throws IOException {
     if (sourceFile == null || !sourceFile.isFile()) {
       // Nothing to do.
+      LOGGER.debug("replaceEnvVars received a null or missing file.");
       return null;
     }
     StringSubstitutor envSub = new StringSubstitutor(System.getenv());

--- a/src/main/java/com/microsoft/lst_bench/util/StringUtils.java
+++ b/src/main/java/com/microsoft/lst_bench/util/StringUtils.java
@@ -96,7 +96,6 @@ public class StringUtils {
       return null;
     }
     StringSubstitutor envSub = new StringSubstitutor(System.getenv());
-    envSub.setValueDelimiter(":");
     return envSub.replace(FileUtils.readFileToString(sourceFile, StandardCharsets.UTF_8));
   }
 }

--- a/src/main/java/com/microsoft/lst_bench/util/StringUtils.java
+++ b/src/main/java/com/microsoft/lst_bench/util/StringUtils.java
@@ -19,9 +19,13 @@ import com.microsoft.lst_bench.exec.FileExec;
 import com.microsoft.lst_bench.exec.ImmutableFileExec;
 import com.microsoft.lst_bench.exec.ImmutableStatementExec;
 import com.microsoft.lst_bench.exec.StatementExec;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.text.StringSubstitutor;
 
 /** Utility class for string operations. */
@@ -74,5 +78,15 @@ public class StringUtils {
                     ImmutableStatementExec.of(
                         s.getId(), pattern.matcher(s.getStatement()).replaceAll(replacement)))
             .collect(Collectors.toList()));
+  }
+
+  public static String replaceEnvVars(File sourceFile) throws IOException {
+    if (sourceFile == null || !sourceFile.isFile()) {
+      // Nothing to do.
+      return null;
+    }
+    StringSubstitutor envSub = new StringSubstitutor(System.getenv());
+    envSub.setValueDelimiter(":");
+    return envSub.replace(FileUtils.readFileToString(sourceFile, StandardCharsets.UTF_8));
   }
 }

--- a/src/main/resources/config/spark/sample_connections_config.yaml
+++ b/src/main/resources/config/spark/sample_connections_config.yaml
@@ -5,7 +5,7 @@ connections:
 - id: spark_0
   driver: org.apache.hive.jdbc.HiveDriver
   url: jdbc:hive2://127.0.0.1:10000
-  username: ${DATABASE_USER:spark_admin}
+  username: ${DATABASE_USER:-spark_admin}
   password: ${DATABASE_PASSWORD}
 - id: spark_1
   type: jdbc

--- a/src/main/resources/config/spark/sample_connections_config.yaml
+++ b/src/main/resources/config/spark/sample_connections_config.yaml
@@ -5,8 +5,8 @@ connections:
 - id: spark_0
   driver: org.apache.hive.jdbc.HiveDriver
   url: jdbc:hive2://127.0.0.1:10000
-  username: admin
-  password: p@ssw0rd0
+  username: ${DATABASE_USER:spark_admin}
+  password: ${DATABASE_PASSWORD}
 - id: spark_1
   type: jdbc
   driver: org.apache.hive.jdbc.HiveDriver

--- a/src/test/java/com/microsoft/lst_bench/DriverSparkTest.java
+++ b/src/test/java/com/microsoft/lst_bench/DriverSparkTest.java
@@ -15,14 +15,13 @@
  */
 package com.microsoft.lst_bench;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.microsoft.lst_bench.input.TaskLibrary;
 import com.microsoft.lst_bench.input.Workload;
 import com.microsoft.lst_bench.input.config.ConnectionsConfig;
 import com.microsoft.lst_bench.input.config.ExperimentConfig;
 import com.microsoft.lst_bench.input.config.ImmutableExperimentConfig;
 import com.microsoft.lst_bench.input.config.TelemetryConfig;
+import com.microsoft.lst_bench.util.FileParser;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -158,12 +157,11 @@ public class DriverSparkTest {
       String arg0, String arg1, String arg2, String arg3, String arg4, Path tempDir)
       throws Exception {
     // Create Java objects from input files
-    final ObjectMapper mapper = new YAMLMapper();
-    TaskLibrary taskLibrary = mapper.readValue(new File(arg0), TaskLibrary.class);
-    Workload workload = mapper.readValue(new File(arg1), Workload.class);
-    ConnectionsConfig connectionsConfig = mapper.readValue(new File(arg2), ConnectionsConfig.class);
-    ExperimentConfig experimentConfig = mapper.readValue(new File(arg3), ExperimentConfig.class);
-    TelemetryConfig telemetryConfig = mapper.readValue(new File(arg4), TelemetryConfig.class);
+    TaskLibrary taskLibrary = FileParser.createObject(arg0, TaskLibrary.class);
+    Workload workload = FileParser.createObject(arg1, Workload.class);
+    ConnectionsConfig connectionsConfig = FileParser.createObject(arg2, ConnectionsConfig.class);
+    ExperimentConfig experimentConfig = FileParser.createObject(arg3, ExperimentConfig.class);
+    TelemetryConfig telemetryConfig = FileParser.createObject(arg4, TelemetryConfig.class);
 
     // Setup path
     experimentConfig = ingestTempDir(experimentConfig, tempDir);

--- a/src/test/java/com/microsoft/lst_bench/common/LSTBenchmarkExecutorTest.java
+++ b/src/test/java/com/microsoft/lst_bench/common/LSTBenchmarkExecutorTest.java
@@ -15,8 +15,6 @@
  */
 package com.microsoft.lst_bench.common;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.microsoft.lst_bench.client.ClientException;
 import com.microsoft.lst_bench.client.Connection;
 import com.microsoft.lst_bench.client.ConnectionManager;
@@ -30,6 +28,7 @@ import com.microsoft.lst_bench.input.config.ImmutableExperimentConfig;
 import com.microsoft.lst_bench.input.config.ImmutableJDBCConnectionConfig;
 import com.microsoft.lst_bench.input.config.TelemetryConfig;
 import com.microsoft.lst_bench.telemetry.SQLTelemetryRegistry;
+import com.microsoft.lst_bench.util.FileParser;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -94,7 +93,6 @@ class LSTBenchmarkExecutorTest {
    */
   @Test
   void testExperimentTimelineTelemetry() throws Exception {
-    ObjectMapper mapper = new YAMLMapper();
 
     Connection mockConnection = Mockito.mock(Connection.class);
     ConnectionManager mockConnectionManager = Mockito.mock(ConnectionManager.class);
@@ -111,12 +109,12 @@ class LSTBenchmarkExecutorTest {
     URL taskLibFile =
         getClass().getClassLoader().getResource("./config/samples/task_library_0.yaml");
     Assertions.assertNotNull(taskLibFile);
-    TaskLibrary taskLibrary = mapper.readValue(new File(taskLibFile.getFile()), TaskLibrary.class);
+    TaskLibrary taskLibrary = FileParser.createObject(taskLibFile.getFile(), TaskLibrary.class);
 
     URL workloadFile =
         getClass().getClassLoader().getResource("./config/spark/w_all_tpcds-delta.yaml");
     Assertions.assertNotNull(workloadFile);
-    Workload workload = mapper.readValue(new File(workloadFile.getFile()), Workload.class);
+    Workload workload = FileParser.createObject(workloadFile.getFile(), Workload.class);
 
     var config = BenchmarkObjectFactory.benchmarkConfig(experimentConfig, taskLibrary, workload);
 
@@ -144,9 +142,8 @@ class LSTBenchmarkExecutorTest {
     URL telemetryConfigFile =
         getClass().getClassLoader().getResource("./config/spark/telemetry_config.yaml");
     Assertions.assertNotNull(telemetryConfigFile);
-    ObjectMapper mapper = new YAMLMapper();
     TelemetryConfig telemetryConfig =
-        mapper.readValue(new File(telemetryConfigFile.getFile()), TelemetryConfig.class);
+        FileParser.createObject(telemetryConfigFile.getFile(), TelemetryConfig.class);
 
     var uniqueTelemetryDbName =
         ImmutableJDBCConnectionConfig.builder()

--- a/src/test/java/com/microsoft/lst_bench/input/ParserTest.java
+++ b/src/test/java/com/microsoft/lst_bench/input/ParserTest.java
@@ -15,13 +15,12 @@
  */
 package com.microsoft.lst_bench.input;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.microsoft.lst_bench.input.config.ConnectionsConfig;
 import com.microsoft.lst_bench.input.config.ExperimentConfig;
 import com.microsoft.lst_bench.input.config.JDBCConnectionConfig;
 import com.microsoft.lst_bench.input.config.SparkConnectionConfig;
 import com.microsoft.lst_bench.input.config.TelemetryConfig;
+import com.microsoft.lst_bench.util.FileParser;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -47,10 +46,9 @@ public class ParserTest {
 
   @Test
   public void testParseExperimentConfig() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     ExperimentConfig experimentConfig =
-        mapper.readValue(
-            new File(CONFIG_PATH + "sample_experiment_config.yaml"), ExperimentConfig.class);
+        FileParser.createObject(
+            CONFIG_PATH + "sample_experiment_config.yaml", ExperimentConfig.class);
     Assertions.assertEquals(1, experimentConfig.getVersion());
     Assertions.assertEquals("spark_del_sf_10", experimentConfig.getId());
     Assertions.assertNotNull(experimentConfig.getMetadata());
@@ -86,10 +84,9 @@ public class ParserTest {
 
   @Test
   public void testParseConnectionConfig() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     ConnectionsConfig connectionsConfig =
-        mapper.readValue(
-            new File(CONFIG_PATH + "sample_connections_config.yaml"), ConnectionsConfig.class);
+        FileParser.createObject(
+            CONFIG_PATH + "sample_connections_config.yaml", ConnectionsConfig.class);
     Assertions.assertEquals(1, connectionsConfig.getVersion());
     Assertions.assertEquals(3, connectionsConfig.getConnections().size());
     JDBCConnectionConfig connection0 =
@@ -97,8 +94,9 @@ public class ParserTest {
     Assertions.assertEquals("spark_0", connection0.getId());
     Assertions.assertEquals("org.apache.hive.jdbc.HiveDriver", connection0.getDriver());
     Assertions.assertEquals("jdbc:hive2://127.0.0.1:10000", connection0.getUrl());
-    Assertions.assertEquals("admin", connection0.getUsername());
-    Assertions.assertEquals("p@ssw0rd0", connection0.getPassword());
+    Assertions.assertEquals("spark_admin", connection0.getUsername()); // Default value.
+    Assertions.assertEquals(
+        "p@ssw0rd0", connection0.getPassword()); // Set via DATABASE_PASSWORD environment variable.
     JDBCConnectionConfig connection1 =
         (JDBCConnectionConfig) connectionsConfig.getConnections().get(1);
     Assertions.assertEquals("spark_1", connection1.getId());
@@ -115,11 +113,9 @@ public class ParserTest {
 
   @Test
   public void testParseTaskLibrary() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     TaskLibrary taskLibrary =
-        mapper.readValue(
-            new File(CONFIG_PATH + "tpcds" + File.separator + "task_library.yaml"),
-            TaskLibrary.class);
+        FileParser.createObject(
+            CONFIG_PATH + "tpcds" + File.separator + "task_library.yaml", TaskLibrary.class);
     Assertions.assertEquals(1, taskLibrary.getVersion());
     Assertions.assertEquals(12, taskLibrary.getTaskTemplates().size());
     for (TaskTemplate taskTemplate : taskLibrary.getTaskTemplates()) {
@@ -168,11 +164,9 @@ public class ParserTest {
 
   @Test
   public void testParseW0Delta() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     Workload workload =
-        mapper.readValue(
-            new File(CONFIG_PATH + "tpcds" + File.separator + "w0_tpcds-delta.yaml"),
-            Workload.class);
+        FileParser.createObject(
+            CONFIG_PATH + "tpcds" + File.separator + "w0_tpcds-delta.yaml", Workload.class);
     Assertions.assertEquals(1, workload.getVersion());
     Assertions.assertEquals("w0_tpcds", workload.getId());
     Assertions.assertEquals(9, workload.getPhases().size());
@@ -232,11 +226,9 @@ public class ParserTest {
 
   @Test
   public void testParseW0Hudi() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     Workload workload =
-        mapper.readValue(
-            new File(CONFIG_PATH + "tpcds" + File.separator + "w0_tpcds-hudi.yaml"),
-            Workload.class);
+        FileParser.createObject(
+            CONFIG_PATH + "tpcds" + File.separator + "w0_tpcds-hudi.yaml", Workload.class);
     Assertions.assertEquals(1, workload.getVersion());
     Assertions.assertEquals("w0_tpcds", workload.getId());
     Assertions.assertEquals(9, workload.getPhases().size());
@@ -311,11 +303,9 @@ public class ParserTest {
 
   @Test
   public void testParseW0Iceberg() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     Workload workload =
-        mapper.readValue(
-            new File(CONFIG_PATH + "tpcds" + File.separator + "w0_tpcds-iceberg.yaml"),
-            Workload.class);
+        FileParser.createObject(
+            CONFIG_PATH + "tpcds" + File.separator + "w0_tpcds-iceberg.yaml", Workload.class);
     Assertions.assertEquals(1, workload.getVersion());
     Assertions.assertEquals("w0_tpcds", workload.getId());
     Assertions.assertEquals(9, workload.getPhases().size());
@@ -375,11 +365,9 @@ public class ParserTest {
 
   @Test
   public void testParseWP1Longevity() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     Workload workload =
-        mapper.readValue(
-            new File(CONFIG_PATH + "tpcds" + File.separator + "wp1_longevity.yaml"),
-            Workload.class);
+        FileParser.createObject(
+            CONFIG_PATH + "tpcds" + File.separator + "wp1_longevity.yaml", Workload.class);
     Assertions.assertEquals(1, workload.getVersion());
     Assertions.assertEquals("wp1_longevity", workload.getId());
     Assertions.assertEquals(15, workload.getPhases().size());
@@ -387,11 +375,9 @@ public class ParserTest {
 
   @Test
   public void testParseWP2Resilience() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     Workload workload =
-        mapper.readValue(
-            new File(CONFIG_PATH + "tpcds" + File.separator + "wp2_resilience.yaml"),
-            Workload.class);
+        FileParser.createObject(
+            CONFIG_PATH + "tpcds" + File.separator + "wp2_resilience.yaml", Workload.class);
     Assertions.assertEquals(1, workload.getVersion());
     Assertions.assertEquals("wp2_resilience", workload.getId());
     Assertions.assertEquals(17, workload.getPhases().size());
@@ -424,11 +410,9 @@ public class ParserTest {
 
   @Test
   public void testParseWP3RWConcurrency() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     Workload workload =
-        mapper.readValue(
-            new File(CONFIG_PATH + "tpcds" + File.separator + "wp3_rw_concurrency.yaml"),
-            Workload.class);
+        FileParser.createObject(
+            CONFIG_PATH + "tpcds" + File.separator + "wp3_rw_concurrency.yaml", Workload.class);
     Assertions.assertEquals(1, workload.getVersion());
     Assertions.assertEquals("wp3_rw_concurrency", workload.getId());
     Assertions.assertEquals(10, workload.getPhases().size());
@@ -493,10 +477,9 @@ public class ParserTest {
 
   @Test
   public void testParseWP3RWConcurrencyMulti() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     Workload workload =
-        mapper.readValue(
-            new File(CONFIG_PATH + "tpcds" + File.separator + "wp3_rw_concurrency_multi.yaml"),
+        FileParser.createObject(
+            CONFIG_PATH + "tpcds" + File.separator + "wp3_rw_concurrency_multi.yaml",
             Workload.class);
     Assertions.assertEquals(1, workload.getVersion());
     Assertions.assertEquals("wp3_rw_concurrency_multi", workload.getId());
@@ -539,11 +522,9 @@ public class ParserTest {
 
   @Test
   public void testParseWP4TimeTravel() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     Workload workload =
-        mapper.readValue(
-            new File(CONFIG_PATH + "tpcds" + File.separator + "wp4_time_travel.yaml"),
-            Workload.class);
+        FileParser.createObject(
+            CONFIG_PATH + "tpcds" + File.separator + "wp4_time_travel.yaml", Workload.class);
     Assertions.assertEquals(1, workload.getVersion());
     Assertions.assertEquals("wp4_time_travel", workload.getId());
     Assertions.assertEquals(18, workload.getPhases().size());
@@ -596,10 +577,9 @@ public class ParserTest {
 
   @Test
   public void testParseTelemetryConfig() throws IOException {
-    ObjectMapper mapper = new YAMLMapper();
     TelemetryConfig telemetryConfig =
-        mapper.readValue(
-            new File(CONFIG_PATH + "sample_telemetry_config.yaml"), TelemetryConfig.class);
+        FileParser.createObject(
+            CONFIG_PATH + "sample_telemetry_config.yaml", TelemetryConfig.class);
     Assertions.assertEquals(1, telemetryConfig.getVersion());
     Assertions.assertNotNull(telemetryConfig.getConnection());
     JDBCConnectionConfig connectionConfig = (JDBCConnectionConfig) telemetryConfig.getConnection();

--- a/src/test/java/com/microsoft/lst_bench/input/ParserTest.java
+++ b/src/test/java/com/microsoft/lst_bench/input/ParserTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 /** Tests for YAML parser into POJO representation. */
 @DisabledIfSystemProperty(named = "lst-bench.test.db", matches = ".*")
@@ -83,6 +84,7 @@ public class ParserTest {
   }
 
   @Test
+  @SetEnvironmentVariable(key = "DATABASE_PASSWORD", value = "p@ssw0rd0")
   public void testParseConnectionConfig() throws IOException {
     ConnectionsConfig connectionsConfig =
         FileParser.createObject(

--- a/src/test/java/com/microsoft/lst_bench/input/ValidationTest.java
+++ b/src/test/java/com/microsoft/lst_bench/input/ValidationTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.microsoft.lst_bench.input.config.ConnectionsConfig;
 import com.microsoft.lst_bench.input.config.ExperimentConfig;
 import com.microsoft.lst_bench.input.config.TelemetryConfig;
+import com.microsoft.lst_bench.util.FileParser;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
@@ -96,7 +97,7 @@ public class ValidationTest {
         0, errorsFromFile.size(), () -> "Errors found in validation: " + errorsFromFile);
     // Validate YAML generated from POJO object
     ExperimentConfig experimentConfig =
-        mapper.readValue(new File(experimentConfigFilePath), ExperimentConfig.class);
+        FileParser.createObject(experimentConfigFilePath, ExperimentConfig.class);
     JsonNode jsonNodeObject = mapper.convertValue(experimentConfig, JsonNode.class);
     Set<ValidationMessage> errorsFromPOJO = schema.validate(jsonNodeObject);
     Assertions.assertEquals(
@@ -144,7 +145,7 @@ public class ValidationTest {
         0, errorsFromFile.size(), () -> "Errors found in validation: " + errorsFromFile);
     // Validate YAML generated from POJO object
     ConnectionsConfig connectionsConfig =
-        mapper.readValue(new File(configFilePath), ConnectionsConfig.class);
+        FileParser.createObject(configFilePath, ConnectionsConfig.class);
     JsonNode jsonNodeObject = mapper.convertValue(connectionsConfig, JsonNode.class);
     Set<ValidationMessage> errorsFromPOJO = schema.validate(jsonNodeObject);
     Assertions.assertEquals(
@@ -185,9 +186,8 @@ public class ValidationTest {
         0, errorsFromFile.size(), () -> "Errors found in validation: " + errorsFromFile);
     // Validate YAML generated from POJO object
     TaskLibrary taskLibrary =
-        mapper.readValue(
-            new File(configPath + "tpcds" + File.separator + "task_library.yaml"),
-            TaskLibrary.class);
+        FileParser.createObject(
+            configPath + "tpcds" + File.separator + "task_library.yaml", TaskLibrary.class);
     JsonNode jsonNodeObject = mapper.convertValue(taskLibrary, JsonNode.class);
     Set<ValidationMessage> errorsFromPOJO = schema.validate(jsonNodeObject);
     Assertions.assertEquals(
@@ -251,7 +251,7 @@ public class ValidationTest {
     Assertions.assertEquals(
         0, errorsFromFile.size(), () -> "Errors found in validation: " + errorsFromFile);
     // Validate YAML generated from POJO object
-    Workload workload = mapper.readValue(new File(workloadFilePath), Workload.class);
+    Workload workload = FileParser.createObject(workloadFilePath, Workload.class);
     JsonNode jsonNodeObject = mapper.convertValue(workload, JsonNode.class);
     Set<ValidationMessage> errorsFromPOJO = schema.validate(jsonNodeObject);
     Assertions.assertEquals(
@@ -291,8 +291,7 @@ public class ValidationTest {
         0, errorsFromFile.size(), () -> "Errors found in validation: " + errorsFromFile);
     // Validate YAML generated from POJO object
     TelemetryConfig telemetryConfig =
-        mapper.readValue(
-            new File(configPath + "sample_telemetry_config.yaml"), TelemetryConfig.class);
+        FileParser.createObject(configPath + "sample_telemetry_config.yaml", TelemetryConfig.class);
     JsonNode jsonNodeObject = mapper.convertValue(telemetryConfig, JsonNode.class);
     Set<ValidationMessage> errorsFromPOJO = schema.validate(jsonNodeObject);
     Assertions.assertEquals(


### PR DESCRIPTION
(Addresses #15 )This change enables lst-bench to substitute parameter values with environment variables, making it easier to reconfigure individual parameters without having to rewrite the entire config files.

Use the StringSubstitutor class to identify and replace environment variables or default values (if provided). 
It supports the standard YAML syntax as follows: 
```
parameter: ${ENV_VAR:default-value}
``` 

The change also involves some minor refactoring to ensure each call to readValue if preceded by a call to replace references to environment variables. 

Testing: 
Modified the ParseTest.testParseConnectionConfig() test to ensure lst-bench substitutes environment variables or uses default values (when present). 

