### PR TITLE
Perf stresstest workload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
             <version>1.1.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.13.0</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/main/java/com/microsoft/lst_bench/common/ConcurrentPerfStresstestTaskExecutor.java
+++ b/src/main/java/com/microsoft/lst_bench/common/ConcurrentPerfStresstestTaskExecutor.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.lst_bench.common;
+
+import com.microsoft.lst_bench.client.ClientException;
+import com.microsoft.lst_bench.client.Connection;
+import com.microsoft.lst_bench.exec.FileExec;
+import com.microsoft.lst_bench.exec.ImmutableStatementExec;
+import com.microsoft.lst_bench.exec.StatementExec;
+import com.microsoft.lst_bench.exec.TaskExec;
+import com.microsoft.lst_bench.input.BenchmarkObjectFactory;
+import com.microsoft.lst_bench.input.Task.CustomTaskExecutorArguments;
+import com.microsoft.lst_bench.telemetry.EventInfo.Status;
+import com.microsoft.lst_bench.telemetry.SQLTelemetryRegistry;
+import com.microsoft.lst_bench.util.StringUtils;
+import java.time.Instant;
+import java.util.Map;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Custom task executor implementation that allows users to execute dependent tasks. We call a
+ * dependent task a task that iteratively executes a) a statement that is expected to return a
+ * result; and b) a statement repeatedly that is expected to use that result. The result of the
+ * first statement is stored in an intermediate object that can be specific to the connection. The
+ * expected object for a JDBC connection is of type List<Map<String, Object>>, handling of other
+ * objects would need to be added to the if-clause that checks the instance of the object.
+ */
+public class ConcurrentPerfStresstestTaskExecutor extends CustomTaskExecutor {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ConcurrentPerfStresstestTaskExecutor.class);
+
+  public ConcurrentPerfStresstestTaskExecutor(
+      SQLTelemetryRegistry telemetryRegistry,
+      String experimentStartTime,
+      CustomTaskExecutorArguments arguments) {
+    super(telemetryRegistry, experimentStartTime, arguments);
+  }
+
+  @Override
+  public void executeTask(Connection connection, TaskExec task, Map<String, Object> values)
+      throws ClientException {
+    // Will never be null since they are set to default values.
+    int numJoins = this.getArguments().getConcurrentTaskNumJoins();
+    int minQueryLength = this.getArguments().getConcurrentTaskMinQueryLength();
+
+    for (FileExec file : task.getFiles()) {
+      Instant fileStartTime = Instant.now();
+
+      if (file.getStatements().size() != 1) {
+        writeFileEvent(fileStartTime, file.getId(), Status.FAILURE);
+        throw new ClientException("Concurrent task execution requires one statement per file.");
+      }
+      StatementExec statement = file.getStatements().get(0);
+
+      if (statement.getStatement().contains("WHERE")
+          || statement.getStatement().contains("ORDER")
+          || statement.getStatement().contains(";")) {
+        writeStatementEvent(
+            fileStartTime,
+            file.getId(),
+            Status.FAILURE,
+            /* payload= */ "Query contains invalid key words (WHERE, ORDER, etc.): "
+                + statement.getStatement());
+        throw new ClientException(
+            "Query contains invalid key words (WHERE, ORDER, etc.): " + statement.getStatement());
+      } else if (!statement.getStatement().contains("FROM")) {
+        writeStatementEvent(
+            fileStartTime,
+            file.getId(),
+            Status.FAILURE,
+            /* payload= */ "Query does not contain keyword 'FROM': " + statement.getStatement());
+        throw new ClientException(
+            "Query does not contain keyword 'FROM': " + statement.getStatement());
+      }
+
+      try {
+        String query = statement.getStatement().split(";")[0];
+        String join_clause = query.split("FROM")[1].trim();
+        // Adjust number of joins.
+        for (int i = 0; i < numJoins; i++) {
+          query += ", " + join_clause + i;
+        }
+        // Adjust query padding.
+        int queryPadding = minQueryLength - query.length();
+        if (queryPadding > 0) {
+          query += new String(new char[queryPadding]).replace('\0', ' ');
+        }
+
+        StatementExec mod_statement =
+            ImmutableStatementExec.of(
+                statement.getId()
+                    + BenchmarkObjectFactory.DEFAULT_ID_SEPARATOR
+                    + "numJoins"
+                    + numJoins
+                    + BenchmarkObjectFactory.DEFAULT_ID_CONNECTOR
+                    + "minQueryLength"
+                    + minQueryLength,
+                query);
+        executeStatement(connection, values, mod_statement);
+      } catch (ClientException e) {
+        LOGGER.error("Exception executing file: " + file.getId());
+        writeFileEvent(fileStartTime, file.getId(), Status.FAILURE);
+        throw e;
+      }
+      writeFileEvent(fileStartTime, file.getId(), Status.SUCCESS);
+    }
+  }
+
+  private void executeStatement(
+      Connection connection, Map<String, Object> values, StatementExec statement)
+      throws ClientException {
+    Instant statementStartTime = Instant.now();
+    try {
+      connection.execute(StringUtils.replaceParameters(statement, values).getStatement());
+    } catch (Exception e) {
+      String error_msg =
+          "Exception executing statement: "
+              + statement.getId()
+              + "; "
+              + ExceptionUtils.getStackTrace(e);
+      LOGGER.error(error_msg);
+      writeStatementEvent(statementStartTime, statement.getId(), Status.FAILURE, error_msg);
+      throw new ClientException(error_msg);
+    }
+    writeStatementEvent(statementStartTime, statement.getId(), Status.SUCCESS, /* payload= */ null);
+  }
+}

--- a/src/main/java/com/microsoft/lst_bench/common/CustomTaskExecutor.java
+++ b/src/main/java/com/microsoft/lst_bench/common/CustomTaskExecutor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.lst_bench.common;
+
+import com.microsoft.lst_bench.client.ClientException;
+import com.microsoft.lst_bench.client.Connection;
+import com.microsoft.lst_bench.exec.TaskExec;
+import com.microsoft.lst_bench.input.Task.CustomTaskExecutorArguments;
+import com.microsoft.lst_bench.telemetry.SQLTelemetryRegistry;
+import java.util.Map;
+
+/**
+ * Custom task executor implementation that allows users to execute dependent tasks. We call a
+ * dependent task a task that iteratively executes a) a statement that is expected to return a
+ * result; and b) a statement repeatedly that is expected to use that result. The result of the
+ * first statement is stored in an intermediate object that can be specific to the connection. The
+ * expected object for a JDBC connection is of type List<Map<String, Object>>, handling of other
+ * objects would need to be added to the if-clause that checks the instance of the object.
+ */
+public class CustomTaskExecutor extends TaskExecutor {
+
+  protected final CustomTaskExecutorArguments arguments;
+
+  public CustomTaskExecutor(
+      SQLTelemetryRegistry telemetryRegistry,
+      String experimentStartTime,
+      CustomTaskExecutorArguments arguments) {
+    super(telemetryRegistry, experimentStartTime);
+    this.arguments = arguments;
+  }
+
+  @Override
+  public void executeTask(Connection connection, TaskExec task, Map<String, Object> values)
+      throws ClientException {
+    super.executeTask(connection, task, values);
+  }
+
+  protected CustomTaskExecutorArguments getArguments() {
+    return this.arguments;
+  }
+}

--- a/src/main/java/com/microsoft/lst_bench/common/DependentTaskExecutor.java
+++ b/src/main/java/com/microsoft/lst_bench/common/DependentTaskExecutor.java
@@ -39,11 +39,9 @@ import org.slf4j.LoggerFactory;
  * expected object for a JDBC connection is of type List<Map<String, Object>>, handling of other
  * objects would need to be added to the if-clause that checks the instance of the object.
  */
-public class DependentTaskExecutor extends TaskExecutor {
+public class DependentTaskExecutor extends CustomTaskExecutor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DependentTaskExecutor.class);
-
-  private final CustomTaskExecutorArguments arguments;
 
   private final int DEFAULT_BATCH_SIZE = 1;
 
@@ -51,18 +49,17 @@ public class DependentTaskExecutor extends TaskExecutor {
       SQLTelemetryRegistry telemetryRegistry,
       String experimentStartTime,
       CustomTaskExecutorArguments arguments) {
-    super(telemetryRegistry, experimentStartTime);
-    this.arguments = arguments;
+    super(telemetryRegistry, experimentStartTime, arguments);
   }
 
   @Override
   public void executeTask(Connection connection, TaskExec task, Map<String, Object> values)
       throws ClientException {
     int batch_size;
-    if (this.arguments == null || this.arguments.getDependentTaskBatchSize() == null) {
+    if (this.getArguments() == null || this.getArguments().getDependentTaskBatchSize() == null) {
       batch_size = DEFAULT_BATCH_SIZE;
     } else {
-      batch_size = this.arguments.getDependentTaskBatchSize().intValue();
+      batch_size = this.getArguments().getDependentTaskBatchSize().intValue();
     }
 
     QueryResult queryResult = null;

--- a/src/main/java/com/microsoft/lst_bench/common/SessionExecutor.java
+++ b/src/main/java/com/microsoft/lst_bench/common/SessionExecutor.java
@@ -34,6 +34,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,7 +86,11 @@ public class SessionExecutor implements Callable<Boolean> {
         writeTaskEvent(taskStartTime, task.getId(), Status.SUCCESS);
       }
     } catch (Exception e) {
-      LOGGER.error("Exception executing session: " + session.getId());
+      LOGGER.error(
+          "Exception executing session: "
+              + session.getId()
+              + ";"
+              + ExceptionUtils.getStackTrace(e));
       writeSessionEvent(sessionStartTime, session.getId(), Status.FAILURE);
       throw e;
     }

--- a/src/main/java/com/microsoft/lst_bench/input/Session.java
+++ b/src/main/java/com/microsoft/lst_bench/input/Session.java
@@ -34,4 +34,10 @@ public interface Session {
 
   @JsonProperty("target_endpoint")
   @Nullable Integer getTargetEndpoint();
+
+  @JsonProperty("duplicate_session")
+  @Value.Default
+  default int getDuplicateSession() {
+    return 0;
+  }
 }

--- a/src/main/java/com/microsoft/lst_bench/input/Task.java
+++ b/src/main/java/com/microsoft/lst_bench/input/Task.java
@@ -51,6 +51,18 @@ public interface Task {
   interface CustomTaskExecutorArguments {
     @JsonProperty("dependent_task_batch_size")
     @Nullable Integer getDependentTaskBatchSize();
+
+    @JsonProperty("concurrent_task_num_joins")
+    @Value.Default
+    default int getConcurrentTaskNumJoins() {
+      return 0;
+    }
+
+    @JsonProperty("concurrent_task_min_query_length")
+    @Value.Default
+    default int getConcurrentTaskMinQueryLength() {
+      return 0;
+    }
   }
 
   @JsonProperty("replace_regex")

--- a/src/main/java/com/microsoft/lst_bench/sql/SQLParser.java
+++ b/src/main/java/com/microsoft/lst_bench/sql/SQLParser.java
@@ -15,10 +15,6 @@
  */
 package com.microsoft.lst_bench.sql;
 
-import com.microsoft.lst_bench.exec.FileExec;
-import com.microsoft.lst_bench.exec.ImmutableFileExec;
-import com.microsoft.lst_bench.exec.ImmutableStatementExec;
-import com.microsoft.lst_bench.exec.StatementExec;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -35,16 +31,15 @@ public class SQLParser {
     // Defeat instantiation
   }
 
-  public static FileExec getStatements(String filepath) {
+  public static List<String> getStatements(String filepath) {
     return getStatements(new File(filepath));
   }
 
-  public static FileExec getStatements(File file) {
-    final List<StatementExec> statements = new ArrayList<>();
+  public static List<String> getStatements(File file) {
+    final List<String> statements = new ArrayList<>();
     try (BufferedReader br =
         new BufferedReader(
             new InputStreamReader(Files.newInputStream(file.toPath()), StandardCharsets.UTF_8))) {
-      int i = 0;
       for (; ; ) {
         String statement;
         try {
@@ -55,12 +50,12 @@ public class SQLParser {
         if (statement == null) {
           break;
         }
-        statements.add(ImmutableStatementExec.of(file.getName() + "_" + i++, statement));
+        statements.add(statement);
       }
     } catch (IOException e) {
       throw new RuntimeException("Cannot read query in file: " + file, e);
     }
-    return ImmutableFileExec.of(file.getName(), statements);
+    return statements;
   }
 
   private static String nextStatement(BufferedReader reader) throws IOException {

--- a/src/main/java/com/microsoft/lst_bench/util/StringUtils.java
+++ b/src/main/java/com/microsoft/lst_bench/util/StringUtils.java
@@ -50,14 +50,18 @@ public class StringUtils {
     return "'" + str + "'";
   }
 
-  public static StatementExec replaceParameters(
-      StatementExec statement, Map<String, Object> parameterValues) {
+  public static String replaceParameters(String statement, Map<String, Object> parameterValues) {
     if (parameterValues == null || parameterValues.isEmpty()) {
       // Nothing to do
       return statement;
     }
+    return StringUtils.format(statement, parameterValues);
+  }
+
+  public static StatementExec replaceParameters(
+      StatementExec statement, Map<String, Object> parameterValues) {
     return ImmutableStatementExec.of(
-        statement.getId(), StringUtils.format(statement.getStatement(), parameterValues));
+        statement.getId(), replaceParameters(statement.getStatement(), parameterValues));
   }
 
   public static FileExec replaceParameters(FileExec file, Map<String, Object> parameterValues) {

--- a/src/main/resources/schemas/workload.json
+++ b/src/main/resources/schemas/workload.json
@@ -69,6 +69,16 @@
                             "type": "integer",
                             "title": "Batch size for DependentTaskExecutor",
                             "description": "Sets the batch size for a task executed; specific to the DependentTaskExecutor class"
+                          },
+                          "concurrent_task_num_joins": {
+                            "type": "integer",
+                            "title": "List of number of joins that are to be tested",
+                            "description": "Determines how the query will be extended with the number of joins"
+                          },
+                          "concurrent_task_min_query_length": {
+                            "type": "integer",
+                            "title": "List of minimum query lengths that are to be tested",
+                            "description": "Determines how the query will be extended with padding if the minimum query length is not exceeded"
                           }
                         }
                       },
@@ -99,6 +109,11 @@
                   "type": "integer",
                   "title": "Target endpoint index (default: 0)",
                   "description": "The positional index (starting from 0) of the connection manager within the connections configuration file"
+                },
+                "duplicate_session": {
+                  "type": "integer",
+                  "title": "Duplication count for this session",
+                  "description": "Determines how often a session will be duplicated; total session count is duplicate_session + 1 (default: 0)"
                 }
               }
             }

--- a/src/test/java/com/microsoft/lst_bench/input/ParserTest.java
+++ b/src/test/java/com/microsoft/lst_bench/input/ParserTest.java
@@ -496,6 +496,7 @@ public class ParserTest {
             List<Task> tasksDM = sessions.get(1).getTasks();
             Assertions.assertEquals(2, tasksDM.size());
             Assertions.assertEquals(1, sessions.get(1).getTargetEndpoint());
+            Assertions.assertEquals(0, sessions.get(1).getDuplicateSession());
           }
           break;
         case "single_user_2_optimize_1":
@@ -505,6 +506,7 @@ public class ParserTest {
             List<Task> tasksO = sessions.get(1).getTasks();
             Assertions.assertEquals(1, tasksO.size());
             Assertions.assertEquals(1, sessions.get(1).getTargetEndpoint());
+            Assertions.assertEquals(0, sessions.get(1).getDuplicateSession());
           }
           break;
         case "setup":

--- a/src/test/resources/config/sqlserver/experiment_config.yaml
+++ b/src/test/resources/config/sqlserver/experiment_config.yaml
@@ -1,0 +1,7 @@
+# Description: Experiment Configuration
+---
+version: 1
+id: perf-stresstest
+repetitions: 1
+metadata:
+  system: sqlserver

--- a/src/test/resources/config/sqlserver/jdbc_connection_config.yaml
+++ b/src/test/resources/config/sqlserver/jdbc_connection_config.yaml
@@ -1,0 +1,9 @@
+# Description: Connections Configuration
+---
+version: 1
+connections:
+- id: sqlserver_0
+  driver: com.microsoft.sqlserver.jdbc.SQLServerDriver
+  url: jdbc:sqlserver://localhost:1433;encrypt=false;database=testdb;
+  username: $USER
+  password: $PASSWORD

--- a/src/test/resources/config/sqlserver/task_library.yaml
+++ b/src/test/resources/config/sqlserver/task_library.yaml
@@ -1,0 +1,8 @@
+# Description: Tasks Library
+---
+version: 1
+task_templates:
+# Example task template for the base query of the custom concurrent performance stresstest.
+- id: base_query
+  files:
+  - src/test/resources/scripts/sqlserver/perf_stresstest.sql

--- a/src/test/resources/config/sqlserver/telemetry_config.yaml
+++ b/src/test/resources/config/sqlserver/telemetry_config.yaml
@@ -1,0 +1,13 @@
+# Description: Telemetry Configuration
+---
+version: 1
+connection:
+  id: duckdb_0
+  driver: org.duckdb.DuckDBDriver
+  url: jdbc:duckdb:./telemetry
+execute_ddl: true
+ddl_file: 'src/main/resources/scripts/logging/duckdb/ddl.sql'
+insert_file: 'src/main/resources/scripts/logging/duckdb/insert.sql'
+# The following parameter values will be used to replace the variables in the logging statements.
+parameter_values:
+  data_path: ''

--- a/src/test/resources/config/sqlserver/w_perf_stresstest.yaml
+++ b/src/test/resources/config/sqlserver/w_perf_stresstest.yaml
@@ -1,0 +1,20 @@
+# Description: Example for custom concurrent performance stresstest workload
+---
+version: 1
+id: perfstress-test
+phases:
+- id: query_execution_1
+  sessions:
+  - tasks:
+    - template_id: base_query
+      custom_task_executor: com.microsoft.lst_bench.common.ConcurrentPerfStresstestTaskExecutor
+      custom_task_executor_arguments:
+        concurrent_task_num_joins: 5
+    duplicate_session: 5
+- id: query_execution_2
+  sessions:
+  - tasks:
+    - template_id: base_query
+      custom_task_executor: com.microsoft.lst_bench.common.ConcurrentPerfStresstestTaskExecutor
+      custom_task_executor_arguments:
+        concurrent_task_min_query_length: 1000

--- a/src/test/resources/scripts/sqlserver/perf_stresstest.sql
+++ b/src/test/resources/scripts/sqlserver/perf_stresstest.sql
@@ -1,0 +1,1 @@
+SELECT t.* FROM test_table t;


### PR DESCRIPTION
Custom workload that executes performance stress tests by a) increasing the number of joins present in a base query and/or b) query padding. These augmented tasks are executed concurrently by duplicating sessions (if specified by the user). This PR introduces the end-to-end workflow for this workload pattern and addresses the following fixes to the codebase:
1. SQLParser now outputs strings rather than StatementExecs for a cleaner separation of functionality.
2. Event identifiers have been modified to essentially showcase the hierarchy. For example, the first statement in file a, part of task t and executed in session 1 is now identified as 1;t;a;0.
3. Adds a layer of abstraction for custom task execution to be consistent with the argument implementation.

** This PR does not yet contain sufficient test cases and will not be committed until those are added. **