### PR TITLE
Change default for max num retries.

### DIFF
--- a/src/main/java/com/microsoft/lst_bench/client/JDBCConnection.java
+++ b/src/main/java/com/microsoft/lst_bench/client/JDBCConnection.java
@@ -40,7 +40,8 @@ public class JDBCConnection implements Connection {
     Exception last_error = null;
     int error_count = 0;
 
-    while (error_count < this.max_num_retries) {
+    // Retry count is in addition to the 1 default try, thus '<='.
+    while (error_count <= this.max_num_retries) {
       try (Statement s = connection.createStatement()) {
         boolean hasResults = s.execute(sqlText);
         if (hasResults) {
@@ -59,9 +60,9 @@ public class JDBCConnection implements Connection {
 
     if (last_error != null) {
       String last_error_msg =
-          "Query retries ("
+          "Query execution ("
               + this.max_num_retries
-              + ") unsuccessful. Error occurred while executing the following query: "
+              + " retries) unsuccessful. Error occurred while executing the following query: "
               + sqlText
               + "; stack trace: "
               + ExceptionUtils.getStackTrace(last_error);

--- a/src/main/java/com/microsoft/lst_bench/input/config/JDBCConnectionConfig.java
+++ b/src/main/java/com/microsoft/lst_bench/input/config/JDBCConnectionConfig.java
@@ -34,7 +34,7 @@ public interface JDBCConnectionConfig extends ConnectionConfig {
   @JsonProperty("max_num_retries")
   @Value.Default
   default int getMaxNumRetries() {
-    return 1;
+    return 0;
   }
 
   @Nullable String getUsername();

--- a/src/main/resources/schemas/connections_config.json
+++ b/src/main/resources/schemas/connections_config.json
@@ -35,7 +35,7 @@
             },
             "max_num_retries": {
               "type": "integer",
-              "title": "The number of times a query can be retried (default: 1)"
+              "title": "The number of times a query can be retried (default: 0)"
             },
             "username": {
               "type": "string",


### PR DESCRIPTION
Changing the default for 'retries' to 0. This parameter is supposed to represent the additional retries, thus a one-off execution of the query needs to be guaranteed. The total number of query tries is thus 1 + max_num_retries.