### PR TITLE
Fix issue that causes dependent tasks to not be executed

### DIFF
--- a/src/main/java/com/microsoft/lst_bench/client/QueryResult.java
+++ b/src/main/java/com/microsoft/lst_bench/client/QueryResult.java
@@ -80,6 +80,8 @@ public class QueryResult {
           this.valueList.get(key).subList(listMin, listMax).stream()
               .map(s -> s.toString())
               .collect(Collectors.toUnmodifiableList());
+      // TODO: This assumes a VARCHAR type (or implicit casting by the engine),
+      //       we should probably handle it more generically using data types.
       result.put(key, "'" + String.join("','", localList) + "'");
     }
     return result;


### PR DESCRIPTION
Relates to #131.

The patch fixes an issue that was introduced in #131 and causes dependent tasks to not be executed. It includes some refactoring to avoid code duplication in `JDBCConnection`.