### PR TITLE
 Disable tests relying on dependent tasks

### DIFF
--- a/src/main/resources/config/spark/tpcds/task_library.yaml
+++ b/src/main/resources/config/spark/tpcds/task_library.yaml
@@ -452,7 +452,7 @@ task_templates:
   - src/main/resources/scripts/tpcds/optimize_split/spark/o_web_sales_IN-hudi.sql
   - src/main/resources/scripts/tpcds/optimize_split/spark/o_web_sales_NULL-hudi.sql
   - src/main/resources/scripts/tpcds/optimize/spark/o_web_site-hudi.sql
-# Execution of dependent TPC-DS data maintenance queries (Delta)
+# Execution of dependent TPC-DS data maintenance queries
 - id: data_maintenance_dependent
   custom_task_executor: com.microsoft.lst_bench.task.custom.DependentTaskExecutor
   files:

--- a/src/test/java/com/microsoft/lst_bench/common/LSTBenchmarkExecutorTest.java
+++ b/src/test/java/com/microsoft/lst_bench/common/LSTBenchmarkExecutorTest.java
@@ -134,7 +134,7 @@ class LSTBenchmarkExecutorTest {
       while (resultset.next()) {
         totalEvents++;
       }
-      Assertions.assertEquals(179, totalEvents);
+      Assertions.assertEquals(165, totalEvents);
 
       // TODO improve event validation
     }

--- a/src/test/resources/config/spark/w_all_tpcds-delta.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-delta.yaml
@@ -27,19 +27,19 @@ phases:
   sessions:
   - tasks:
     - template_id: data_maintenance_delta
-- id: data_maintenance_dependent
-  sessions:
-  - tasks:
-    - template_id: data_maintenance_dependent
-      task_executor_arguments:
-        dependent_task_batch_size: 100
+#- id: data_maintenance_dependent
+#  sessions:
+#  - tasks:
+#    - template_id: data_maintenance_dependent
+#      task_executor_arguments:
+#        dependent_task_batch_size: 100
 - id: optimize
   sessions:
   - tasks:
     - template_id: optimize_delta
-- id: optimize_split
-  sessions:
-  - tasks:
-    - template_id: optimize_split_delta
-      task_executor_arguments:
-        dependent_task_batch_size: 100
+#- id: optimize_split
+#  sessions:
+#  - tasks:
+#    - template_id: optimize_split_delta
+#      task_executor_arguments:
+#        dependent_task_batch_size: 100

--- a/src/test/resources/config/spark/w_all_tpcds-hudi.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-hudi.yaml
@@ -30,19 +30,19 @@ phases:
   sessions:
   - tasks:
     - template_id: data_maintenance_hudi
-- id: data_maintenance_dependent
-  sessions:
-  - tasks:
-    - template_id: data_maintenance_dependent
-      task_executor_arguments:
-        dependent_task_batch_size: 100
+#- id: data_maintenance_dependent
+#  sessions:
+#  - tasks:
+#    - template_id: data_maintenance_dependent
+#      task_executor_arguments:
+#        dependent_task_batch_size: 100
 - id: optimize
   sessions:
   - tasks:
     - template_id: optimize_hudi
-- id: optimize_split
-  sessions:
-  - tasks:
-    - template_id: optimize_split_hudi
-      task_executor_arguments:
-        dependent_task_batch_size: 100
+#- id: optimize_split
+#  sessions:
+#  - tasks:
+#    - template_id: optimize_split_hudi
+#      task_executor_arguments:
+#        dependent_task_batch_size: 100

--- a/src/test/resources/config/spark/w_all_tpcds-iceberg.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-iceberg.yaml
@@ -30,19 +30,19 @@ phases:
   sessions:
   - tasks:
     - template_id: data_maintenance_iceberg
-- id: data_maintenance_dependent
-  sessions:
-  - tasks:
-    - template_id: data_maintenance_dependent
-      task_executor_arguments:
-        dependent_task_batch_size: 100
+#- id: data_maintenance_dependent
+#  sessions:
+#  - tasks:
+#    - template_id: data_maintenance_dependent
+#      task_executor_arguments:
+#        dependent_task_batch_size: 100
 - id: optimize
   sessions:
   - tasks:
     - template_id: optimize_iceberg
-- id: optimize_split
-  sessions:
-  - tasks:
-    - template_id: optimize_split_iceberg
-      task_executor_arguments:
-        dependent_task_batch_size: 100
+#- id: optimize_split
+#  sessions:
+#  - tasks:
+#    - template_id: optimize_split_iceberg
+#      task_executor_arguments:
+#        dependent_task_batch_size: 100

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-delta.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-delta.yaml
@@ -12,6 +12,6 @@ phases:
     - template_id: build
     - template_id: single_user
     - template_id: data_maintenance_delta
-    - template_id: data_maintenance_dependent
+#    - template_id: data_maintenance_dependent
     - template_id: optimize_delta
-    - template_id: optimize_split_delta
+#    - template_id: optimize_split_delta

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-hudi.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-hudi.yaml
@@ -15,6 +15,6 @@ phases:
           replacement: 'string'
     - template_id: single_user
     - template_id: data_maintenance_hudi
-    - template_id: data_maintenance_dependent
+#    - template_id: data_maintenance_dependent
     - template_id: optimize_hudi
-    - template_id: optimize_split_hudi
+#    - template_id: optimize_split_hudi

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-iceberg.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-iceberg.yaml
@@ -15,6 +15,6 @@ phases:
           replacement: ''
     - template_id: single_user
     - template_id: data_maintenance_iceberg
-    - template_id: data_maintenance_dependent
+#    - template_id: data_maintenance_dependent
     - template_id: optimize_iceberg
-    - template_id: optimize_split_iceberg
+#    - template_id: optimize_split_iceberg


### PR DESCRIPTION
These tests were failing when they were checked in, but due to a bug in error handling, CI incorrectly marked them as passing. We will temporarily disable these tests and re-enable them once we populate the necessary data in the tables used for CI (#182).