### PR TITLE
Re-enable tests relying on dependent tasks

### DIFF
--- a/src/test/java/com/microsoft/lst_bench/DriverSparkTest.java
+++ b/src/test/java/com/microsoft/lst_bench/DriverSparkTest.java
@@ -208,7 +208,7 @@ public class DriverSparkTest {
   @Test
   @EnabledIfSystemProperty(named = "lst-bench.test.lst", matches = "iceberg")
   @EnabledIfSystemProperty(named = "lst-bench.test.connection", matches = "jdbc")
-  public void testJDBCSkipFailedQueriesIceber() throws Exception {
+  public void testJDBCSkipFailedQueriesIceberg() throws Exception {
     runDriver(
         "src/test/resources/config/spark/jdbc_connection_config.yaml",
         "src/test/resources/config/spark/experiment_config-iceberg.yaml",

--- a/src/test/java/com/microsoft/lst_bench/common/LSTBenchmarkExecutorTest.java
+++ b/src/test/java/com/microsoft/lst_bench/common/LSTBenchmarkExecutorTest.java
@@ -134,7 +134,7 @@ class LSTBenchmarkExecutorTest {
       while (resultset.next()) {
         totalEvents++;
       }
-      Assertions.assertEquals(165, totalEvents);
+      Assertions.assertEquals(179, totalEvents);
 
       // TODO improve event validation
     }

--- a/src/test/resources/config/spark/w_all_tpcds-delta.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-delta.yaml
@@ -34,7 +34,7 @@ phases:
       task_executor_arguments:
         dependent_task_batch_size: 100
         # TODO: Remove this once #182 is fixed
-        skip_erroneous_query_strings: "Cannot recognize the predicate"
+        skip_erroneous_query_strings: "[DELTA_FAILED_RECOGNIZE_PREDICATE]"
 - id: optimize
   sessions:
   - tasks:
@@ -46,4 +46,4 @@ phases:
       task_executor_arguments:
         dependent_task_batch_size: 100
         # TODO: Remove this once #182 is fixed
-        skip_erroneous_query_strings: "Cannot recognize the predicate"
+        skip_erroneous_query_strings: "[DELTA_FAILED_RECOGNIZE_PREDICATE]"

--- a/src/test/resources/config/spark/w_all_tpcds-delta.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-delta.yaml
@@ -33,6 +33,8 @@ phases:
     - template_id: data_maintenance_dependent
       task_executor_arguments:
         dependent_task_batch_size: 100
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "Cannot recognize the predicate"
 - id: optimize
   sessions:
   - tasks:
@@ -43,3 +45,5 @@ phases:
     - template_id: optimize_split_delta
       task_executor_arguments:
         dependent_task_batch_size: 100
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "Cannot recognize the predicate"

--- a/src/test/resources/config/spark/w_all_tpcds-delta.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-delta.yaml
@@ -27,19 +27,19 @@ phases:
   sessions:
   - tasks:
     - template_id: data_maintenance_delta
-#- id: data_maintenance_dependent
-#  sessions:
-#  - tasks:
-#    - template_id: data_maintenance_dependent
-#      task_executor_arguments:
-#        dependent_task_batch_size: 100
+- id: data_maintenance_dependent
+  sessions:
+  - tasks:
+    - template_id: data_maintenance_dependent
+      task_executor_arguments:
+        dependent_task_batch_size: 100
 - id: optimize
   sessions:
   - tasks:
     - template_id: optimize_delta
-#- id: optimize_split
-#  sessions:
-#  - tasks:
-#    - template_id: optimize_split_delta
-#      task_executor_arguments:
-#        dependent_task_batch_size: 100
+- id: optimize_split
+  sessions:
+  - tasks:
+    - template_id: optimize_split_delta
+      task_executor_arguments:
+        dependent_task_batch_size: 100

--- a/src/test/resources/config/spark/w_all_tpcds-hudi.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-hudi.yaml
@@ -36,6 +36,8 @@ phases:
     - template_id: data_maintenance_dependent
       task_executor_arguments:
         dependent_task_batch_size: 100
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "[PARSE_SYNTAX_ERROR]"
 - id: optimize
   sessions:
   - tasks:
@@ -46,3 +48,5 @@ phases:
     - template_id: optimize_split_hudi
       task_executor_arguments:
         dependent_task_batch_size: 100
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "[PARSE_SYNTAX_ERROR]"

--- a/src/test/resources/config/spark/w_all_tpcds-hudi.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-hudi.yaml
@@ -30,19 +30,19 @@ phases:
   sessions:
   - tasks:
     - template_id: data_maintenance_hudi
-#- id: data_maintenance_dependent
-#  sessions:
-#  - tasks:
-#    - template_id: data_maintenance_dependent
-#      task_executor_arguments:
-#        dependent_task_batch_size: 100
+- id: data_maintenance_dependent
+  sessions:
+  - tasks:
+    - template_id: data_maintenance_dependent
+      task_executor_arguments:
+        dependent_task_batch_size: 100
 - id: optimize
   sessions:
   - tasks:
     - template_id: optimize_hudi
-#- id: optimize_split
-#  sessions:
-#  - tasks:
-#    - template_id: optimize_split_hudi
-#      task_executor_arguments:
-#        dependent_task_batch_size: 100
+- id: optimize_split
+  sessions:
+  - tasks:
+    - template_id: optimize_split_hudi
+      task_executor_arguments:
+        dependent_task_batch_size: 100

--- a/src/test/resources/config/spark/w_all_tpcds-iceberg.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-iceberg.yaml
@@ -36,7 +36,8 @@ phases:
     - template_id: data_maintenance_dependent
       task_executor_arguments:
         dependent_task_batch_size: 100
-        skip_erroneous_query_strings: Cannot parse predicates in where option
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "Cannot parse predicates in where option"
 - id: optimize
   sessions:
   - tasks:
@@ -47,4 +48,5 @@ phases:
     - template_id: optimize_split_iceberg
       task_executor_arguments:
         dependent_task_batch_size: 100
-        skip_erroneous_query_strings: Cannot parse predicates in where option
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "Cannot parse predicates in where option"

--- a/src/test/resources/config/spark/w_all_tpcds-iceberg.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-iceberg.yaml
@@ -36,7 +36,7 @@ phases:
     - template_id: data_maintenance_dependent
       task_executor_arguments:
         dependent_task_batch_size: 100
-      skip_erroneous_query_strings: Cannot parse predicates in where option
+        skip_erroneous_query_strings: Cannot parse predicates in where option
 - id: optimize
   sessions:
   - tasks:
@@ -47,4 +47,4 @@ phases:
     - template_id: optimize_split_iceberg
       task_executor_arguments:
         dependent_task_batch_size: 100
-      skip_erroneous_query_strings: Cannot parse predicates in where option
+        skip_erroneous_query_strings: Cannot parse predicates in where option

--- a/src/test/resources/config/spark/w_all_tpcds-iceberg.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds-iceberg.yaml
@@ -30,19 +30,21 @@ phases:
   sessions:
   - tasks:
     - template_id: data_maintenance_iceberg
-#- id: data_maintenance_dependent
-#  sessions:
-#  - tasks:
-#    - template_id: data_maintenance_dependent
-#      task_executor_arguments:
-#        dependent_task_batch_size: 100
+- id: data_maintenance_dependent
+  sessions:
+  - tasks:
+    - template_id: data_maintenance_dependent
+      task_executor_arguments:
+        dependent_task_batch_size: 100
+      skip_erroneous_query_strings: Cannot parse predicates in where option
 - id: optimize
   sessions:
   - tasks:
     - template_id: optimize_iceberg
-#- id: optimize_split
-#  sessions:
-#  - tasks:
-#    - template_id: optimize_split_iceberg
-#      task_executor_arguments:
-#        dependent_task_batch_size: 100
+- id: optimize_split
+  sessions:
+  - tasks:
+    - template_id: optimize_split_iceberg
+      task_executor_arguments:
+        dependent_task_batch_size: 100
+      skip_erroneous_query_strings: Cannot parse predicates in where option

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-delta.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-delta.yaml
@@ -13,5 +13,11 @@ phases:
     - template_id: single_user
     - template_id: data_maintenance_delta
     - template_id: data_maintenance_dependent
+      task_executor_arguments:
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "Cannot recognize the predicate"
     - template_id: optimize_delta
     - template_id: optimize_split_delta
+      task_executor_arguments:
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "Cannot recognize the predicate"

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-delta.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-delta.yaml
@@ -15,9 +15,9 @@ phases:
     - template_id: data_maintenance_dependent
       task_executor_arguments:
         # TODO: Remove this once #182 is fixed
-        skip_erroneous_query_strings: "Cannot recognize the predicate"
+        skip_erroneous_query_strings: "[DELTA_FAILED_RECOGNIZE_PREDICATE]"
     - template_id: optimize_delta
     - template_id: optimize_split_delta
       task_executor_arguments:
         # TODO: Remove this once #182 is fixed
-        skip_erroneous_query_strings: "Cannot recognize the predicate"
+        skip_erroneous_query_strings: "[DELTA_FAILED_RECOGNIZE_PREDICATE]"

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-delta.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-delta.yaml
@@ -12,6 +12,6 @@ phases:
     - template_id: build
     - template_id: single_user
     - template_id: data_maintenance_delta
-#    - template_id: data_maintenance_dependent
+    - template_id: data_maintenance_dependent
     - template_id: optimize_delta
-#    - template_id: optimize_split_delta
+    - template_id: optimize_split_delta

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-hudi.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-hudi.yaml
@@ -16,5 +16,11 @@ phases:
     - template_id: single_user
     - template_id: data_maintenance_hudi
     - template_id: data_maintenance_dependent
+      task_executor_arguments:
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "[PARSE_SYNTAX_ERROR]"
     - template_id: optimize_hudi
     - template_id: optimize_split_hudi
+      task_executor_arguments:
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "[PARSE_SYNTAX_ERROR]"

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-hudi.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-hudi.yaml
@@ -15,6 +15,6 @@ phases:
           replacement: 'string'
     - template_id: single_user
     - template_id: data_maintenance_hudi
-#    - template_id: data_maintenance_dependent
+    - template_id: data_maintenance_dependent
     - template_id: optimize_hudi
-#    - template_id: optimize_split_hudi
+    - template_id: optimize_split_hudi

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-iceberg.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-iceberg.yaml
@@ -15,6 +15,6 @@ phases:
           replacement: ''
     - template_id: single_user
     - template_id: data_maintenance_iceberg
-#    - template_id: data_maintenance_dependent
+    - template_id: data_maintenance_dependent
     - template_id: optimize_iceberg
-#    - template_id: optimize_split_iceberg
+    - template_id: optimize_split_iceberg

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-iceberg.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-iceberg.yaml
@@ -17,8 +17,10 @@ phases:
     - template_id: data_maintenance_iceberg
     - template_id: data_maintenance_dependent
       task_executor_arguments:
-        skip_erroneous_query_strings: Cannot parse predicates in where option
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "Cannot parse predicates in where option"
     - template_id: optimize_iceberg
     - template_id: optimize_split_iceberg
       task_executor_arguments:
-        skip_erroneous_query_strings: Cannot parse predicates in where option
+        # TODO: Remove this once #182 is fixed
+        skip_erroneous_query_strings: "Cannot parse predicates in where option"

--- a/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-iceberg.yaml
+++ b/src/test/resources/config/spark/w_all_tpcds_single_session_jdbc-iceberg.yaml
@@ -16,5 +16,9 @@ phases:
     - template_id: single_user
     - template_id: data_maintenance_iceberg
     - template_id: data_maintenance_dependent
+      task_executor_arguments:
+        skip_erroneous_query_strings: Cannot parse predicates in where option
     - template_id: optimize_iceberg
     - template_id: optimize_split_iceberg
+      task_executor_arguments:
+        skip_erroneous_query_strings: Cannot parse predicates in where option


### PR DESCRIPTION
They had been disabled in #181. Re-enable by introducing skip errors for those tasks until #182 is fixed.