### PR TITLE
Include statement id in all the error messages

### DIFF
--- a/src/main/java/com/microsoft/lst_bench/client/JDBCConnection.java
+++ b/src/main/java/com/microsoft/lst_bench/client/JDBCConnection.java
@@ -74,7 +74,7 @@ public class JDBCConnection implements Connection {
         }
         // Log verbosely, if enabled.
         if (this.showWarnings && LOGGER.isWarnEnabled()) {
-          logWarnings(s, false);
+          LOGGER.warn(createWarningString(s));
         }
         // Return here if successful.
         return queryResult;
@@ -83,23 +83,22 @@ public class JDBCConnection implements Connection {
         String lastErrorMsg =
             "Query execution ("
                 + this.maxNumRetries
-                + " retries) unsuccessful; stack trace: "
+                + " retries) unsuccessful; "
+                + "Warnings: "
+                + createWarningString(s)
+                + "stack trace: "
                 + ExceptionUtils.getStackTrace(e);
 
-        // Log any pending warnings associated with this statement, useful for debugging.
-        boolean logAsError = errorCount == this.maxNumRetries;
-        if (LOGGER.isWarnEnabled()) {
-          logWarnings(s, logAsError);
-        }
-
-        if (logAsError) {
-          // Log execution error.
+        // Log execution error and any pending warnings associated with this statement, useful for
+        // debugging.
+        if (errorCount == this.maxNumRetries) {
           LOGGER.error(lastErrorMsg);
           throw new ClientException(lastErrorMsg);
         } else {
           LOGGER.warn(lastErrorMsg);
         }
         errorCount++;
+
       } finally {
         if (s != null) {
           try {
@@ -131,7 +130,7 @@ public class JDBCConnection implements Connection {
     }
   }
 
-  private void logWarnings(Statement s, boolean logAsError) throws ClientException {
+  private String createWarningString(Statement s) throws ClientException {
     List<String> warningList = new ArrayList<>();
 
     if (s != null) {
@@ -147,12 +146,6 @@ public class JDBCConnection implements Connection {
       }
     }
 
-    for (String warning : warningList) {
-      if (logAsError) {
-        LOGGER.error(warning);
-      } else {
-        LOGGER.warn(warning);
-      }
-    }
+    return String.join("; ", warningList);
   }
 }


### PR DESCRIPTION
Investigating issues on failed queries makes sense write in logs all the warning messages to get all the statement ID associated

Before fix:
![image](https://github.com/microsoft/lst-bench/assets/1587480/4dea6fa6-eee2-4f1c-ae8a-0f1b4aba761e)

After fix we include all in the error message line.
<img width="1922" alt="CleanShot 2024-02-09 at 14 02 44@2x" src="https://github.com/microsoft/lst-bench/assets/1587480/c3020fbc-bd61-41fe-b9ba-81714aad770c">


