### PR TITLE
Introduce concurrent execution of tasks within a session

### DIFF
--- a/core/src/main/java/com/microsoft/lst_bench/exec/TaskExec.java
+++ b/core/src/main/java/com/microsoft/lst_bench/exec/TaskExec.java
@@ -37,4 +37,7 @@ public interface TaskExec {
 
   @Value.Parameter(false)
   @Nullable String getCustomTaskExecutor();
+
+  @Value.Parameter(false)
+  @Nullable Long getStart();
 }

--- a/core/src/main/java/com/microsoft/lst_bench/input/BenchmarkObjectFactory.java
+++ b/core/src/main/java/com/microsoft/lst_bench/input/BenchmarkObjectFactory.java
@@ -195,7 +195,10 @@ public class BenchmarkObjectFactory {
       taskExecList.add(taskExec);
     }
     return ImmutableSessionExec.of(
-        sessionId, taskExecList, ObjectUtils.defaultIfNull(session.getTargetEndpoint(), 0));
+        sessionId,
+        taskExecList,
+        ObjectUtils.defaultIfNull(session.getTargetEndpoint(), 0),
+        ObjectUtils.defaultIfNull(session.getMaxConcurrency(), 1));
   }
 
   private static List<Task> getTasksFromSession(Session session, InternalLibrary internalLibrary) {

--- a/core/src/main/java/com/microsoft/lst_bench/input/Session.java
+++ b/core/src/main/java/com/microsoft/lst_bench/input/Session.java
@@ -42,6 +42,9 @@ public interface Session {
   @JsonProperty("target_endpoint")
   @Nullable Integer getTargetEndpoint();
 
+  @JsonProperty("max_concurrency")
+  @Nullable Integer getMaxConcurrency();
+
   /**
    * Validates that a session has exactly one of template ID, list of tasks, or list of tasks
    * sequences defined.

--- a/core/src/main/java/com/microsoft/lst_bench/input/Task.java
+++ b/core/src/main/java/com/microsoft/lst_bench/input/Task.java
@@ -53,6 +53,9 @@ public interface Task {
   @JsonProperty("replace_regex")
   @Nullable List<ReplaceRegex> getReplaceRegex();
 
+  @JsonProperty("start")
+  @Nullable Long getStart();
+
   @Value.Immutable
   @JsonSerialize(as = ImmutableReplaceRegex.class)
   @JsonDeserialize(as = ImmutableReplaceRegex.class)

--- a/core/src/main/resources/schemas/instance.json
+++ b/core/src/main/resources/schemas/instance.json
@@ -75,6 +75,12 @@
                     },
                     "additionalProperties": false
                   }
+                },
+                "start": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "title": "Start time of the task",
+                  "description": "Time when the task should start relative to beginning of the session (in milliseconds). If not specified, a task starts immediately after the end of the previous task"
                 }
               }
             }
@@ -146,6 +152,12 @@
               "type": "integer",
               "title": "Target endpoint index (default: 0)",
               "description": "The positional index (starting from 0) of the connection manager within the connections configuration file"
+            },
+            "max_concurrency": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Maximum number of concurrent tasks (default: 1)",
+              "description": "Indicates the maximum number of tasks that can be executed concurrently during this session"
             }
           }
         }

--- a/core/src/test/java/com/microsoft/lst_bench/client/QueryResultTest.java
+++ b/core/src/test/java/com/microsoft/lst_bench/client/QueryResultTest.java
@@ -22,7 +22,9 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
+@DisabledIfSystemProperty(named = "lst-bench.test.db", matches = ".*")
 public class QueryResultTest {
 
   @Test

--- a/core/src/test/java/com/microsoft/lst_bench/exec/SessionExecTest.java
+++ b/core/src/test/java/com/microsoft/lst_bench/exec/SessionExecTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.lst_bench.exec;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@DisabledIfSystemProperty(named = "lst-bench.test.db", matches = ".*")
+public class SessionExecTest {
+
+  @Test
+  public void testValidSessionExec() {
+    TaskExec task1 = ImmutableTaskExec.of("task1", List.of()).withStart(1000L);
+    TaskExec task2 = ImmutableTaskExec.of("task2", List.of()).withStart(2000L);
+    SessionExec sessionExec =
+        ImmutableSessionExec.of("session1", Arrays.asList(task1, task2), 0, 1);
+
+    Assertions.assertEquals("session1", sessionExec.getId());
+    Assertions.assertEquals(0, sessionExec.getTargetEndpoint());
+    Assertions.assertEquals(1, sessionExec.getMaxConcurrency());
+    Assertions.assertEquals(2, sessionExec.getTasks().size());
+  }
+
+  @Test
+  public void testInvalidSessionExecWithUnorderedTasks() {
+    TaskExec task1 = ImmutableTaskExec.of("task1", List.of()).withStart(2000L);
+    TaskExec task2 = ImmutableTaskExec.of("task2", List.of()).withStart(1000L);
+
+    IllegalStateException exception =
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> ImmutableSessionExec.of("session1", Arrays.asList(task1, task2), 0, 1));
+
+    Assertions.assertEquals(
+        "Tasks in a session must be in order of start time", exception.getMessage());
+  }
+
+  @Test
+  public void testInvalidSessionExecWithMixedStartTimes() {
+    TaskExec task1 = ImmutableTaskExec.of("task1", List.of()).withStart(1000L);
+    TaskExec task2 = ImmutableTaskExec.of("task2", List.of()).withStart(null);
+
+    IllegalStateException exception =
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> ImmutableSessionExec.of("session1", Arrays.asList(task1, task2), 0, 1));
+
+    Assertions.assertEquals(
+        "Either all tasks in a session must have a start time, or none should have one.",
+        exception.getMessage());
+  }
+
+  @Test
+  public void testValidSessionExecWithoutStartTimes() {
+    TaskExec task1 = ImmutableTaskExec.of("task1", List.of()).withStart(null);
+    TaskExec task2 = ImmutableTaskExec.of("task2", List.of()).withStart(null);
+    SessionExec sessionExec =
+        ImmutableSessionExec.of("session1", Arrays.asList(task1, task2), 0, 1);
+
+    Assertions.assertEquals("session1", sessionExec.getId());
+    Assertions.assertEquals(0, sessionExec.getTargetEndpoint());
+    Assertions.assertEquals(1, sessionExec.getMaxConcurrency());
+    Assertions.assertEquals(2, sessionExec.getTasks().size());
+  }
+}

--- a/core/src/test/resources/config/spark/w_multi_connection-delta.yaml
+++ b/core/src/test/resources/config/spark/w_multi_connection-delta.yaml
@@ -25,14 +25,18 @@ phases:
   sessions:
   - tasks:
     - template_id: single_user
+      start: 1000
     target_endpoint: 0
+    max_concurrency: 1
   - template_id: session_data_maintenance
     target_endpoint: 1
 - id: multi_mixed_2
   sessions:
   - tasks:
     - template_id: single_user
+      start: 1000
     target_endpoint: 0
+    max_concurrency: 1
   - tasks:
     - template_id: optimize_delta
     target_endpoint: 1

--- a/core/src/test/resources/config/spark/w_multi_connection-hudi.yaml
+++ b/core/src/test/resources/config/spark/w_multi_connection-hudi.yaml
@@ -28,14 +28,18 @@ phases:
   sessions:
   - tasks:
     - template_id: single_user
+      start: 1000
     target_endpoint: 0
+    max_concurrency: 1
   - template_id: session_data_maintenance
     target_endpoint: 1
 - id: multi_mixed_2
   sessions:
   - tasks:
     - template_id: single_user
+      start: 1000
     target_endpoint: 0
+    max_concurrency: 1
   - tasks:
     - template_id: optimize_hudi
     target_endpoint: 1

--- a/core/src/test/resources/config/spark/w_multi_connection-iceberg.yaml
+++ b/core/src/test/resources/config/spark/w_multi_connection-iceberg.yaml
@@ -28,14 +28,18 @@ phases:
   sessions:
   - tasks:
     - template_id: single_user
+      start: 1000
     target_endpoint: 0
+    max_concurrency: 1
   - template_id: session_data_maintenance
     target_endpoint: 1
 - id: multi_mixed_2
   sessions:
   - tasks:
     - template_id: single_user
+      start: 1000
     target_endpoint: 0
+    max_concurrency: 1
   - tasks:
     - template_id: optimize_iceberg
     target_endpoint: 1

--- a/docs/workloads.md
+++ b/docs/workloads.md
@@ -1,13 +1,13 @@
 # Definition of Workloads in LST-Bench
 
 In LST-Bench, workloads are defined using a YAML configuration file. 
-The schema for this configuration file can be accessed [here](/src/main/resources/schemas/workload.json). 
-To facilitate the reusability of various workload components, LST-Bench enables the definition of a [library](/src/main/resources/schemas/library.json). 
+The schema for this configuration file can be accessed [here](/core/src/main/resources/schemas/workload.json). 
+To facilitate the reusability of various workload components, LST-Bench enables the definition of a [library](/core/src/main/resources/schemas/library.json). 
 This library should be supplied during benchmark execution, allowing workloads to reference entities predefined within it.
 
 LST-Bench already includes libraries encompassing tasks derived from the TPC-DS and TPC-H benchmarks, along with workload definitions that represent the original workloads specified by these standards. 
 Additionally, multiple other workload patterns that are especially relevant for evaluating LSTs are also included. 
-These resources can be found [here](/src/main/resources/config).
+These resources can be found [here](/core/src/main/resources/config).
 
 While LST-Bench provides predefined libraries and workload definitions, users have the flexibility to incorporate additional task templates or even create an entirely new task library to model specific scenarios. 
 This flexible model allows for the easy creation of diverse SQL workloads for evaluation purposes without necessitating modifications to the LST-Bench application itself.
@@ -30,16 +30,16 @@ task_templates:
 # Execution of a few TPC-DS queries (possibly in a previous point-in-time)
 - id: single_user_simple
   files:
-  - src/main/resources/scripts/tpcds/single_user/spark/query1.sql
-  - src/main/resources/scripts/tpcds/single_user/spark/query2.sql
-  - src/main/resources/scripts/tpcds/single_user/spark/query3.sql
-  permutation_orders_path: src/main/resources/auxiliary/tpcds/single_user/permutation_orders/
+  - core/src/main/resources/scripts/tpcds/single_user/spark/query1.sql
+  - core/src/main/resources/scripts/tpcds/single_user/spark/query2.sql
+  - core/src/main/resources/scripts/tpcds/single_user/spark/query3.sql
+  permutation_orders_path: core/src/main/resources/auxiliary/tpcds/single_user/permutation_orders/
   supports_time_travel: true
 ```
 
 This template with the identifier `single_user_simple` comprises three SQL query files, each with a query. 
 Note that there are a couple of additional optional properties defined, namely `permutation_orders_path` and `supports_time_travel`. 
-Further information about these and other optional properties, including their descriptions, can be found [here](/src/main/resources/schemas/template.json).
+Further information about these and other optional properties, including their descriptions, can be found [here](/core/src/main/resources/schemas/template.json).
 
 ### Task Instance
 
@@ -54,22 +54,22 @@ A task template can also be inlined within the task instantiation if we do not w
 
 ```yaml
 - files:
-  - src/main/resources/scripts/tpcds/single_user/spark/query1.sql
-  - src/main/resources/scripts/tpcds/single_user/spark/query2.sql
-  - src/main/resources/scripts/tpcds/single_user/spark/query3.sql
-  permutation_orders_path: src/main/resources/auxiliary/tpcds/single_user/permutation_orders/
+  - core/src/main/resources/scripts/tpcds/single_user/spark/query1.sql
+  - core/src/main/resources/scripts/tpcds/single_user/spark/query2.sql
+  - core/src/main/resources/scripts/tpcds/single_user/spark/query3.sql
+  permutation_orders_path: core/src/main/resources/auxiliary/tpcds/single_user/permutation_orders/
   permute_order: true
 ```
 
 Note that tasks can also have their parameters modifying their behavior for a specific instance, e.g., `permute_order`. 
-These optional task parameters as well as an explanation about them can be found [here](/src/main/resources/schemas/instance.json).
+These optional task parameters as well as an explanation about them can be found [here](/core/src/main/resources/schemas/instance.json).
 
 ### Custom Tasks
 
 Custom tasks allow users to specify their own task execution classes to change execution order, add dependencies between tasks, or pass custom parameters that influence task execution dynamically, amongst others.
-The exact implementation is left to the user, however, they need to inherit from and abide to the API's of the `TaskExecutor` class that can be found [here](/src/main/java/com/microsoft/lst_bench/task/TaskExecutor.java). 
+The exact implementation is left to the user, however, they need to inherit from and abide to the API's of the `TaskExecutor` class that can be found [here](/core/src/main/java/com/microsoft/lst_bench/task/TaskExecutor.java). 
 The execution class as well as the task's arguments are defined in the workload configuration via the `custom_task_executor` and `task_executor_arguments` keywords respectively.
-An example is shown here, based on the implementation of the custom [DependentTaskExecutor](/src/main/java/com/microsoft/lst_bench/task/custom/DependentTaskExecutor.java) class:
+An example is shown here, based on the implementation of the custom [DependentTaskExecutor](/core/src/main/java/com/microsoft/lst_bench/task/custom/DependentTaskExecutor.java) class:
 
 ```yaml
 - template_id: data_maintenance_dependent
@@ -78,8 +78,8 @@ An example is shown here, based on the implementation of the custom [DependentTa
     dependent_task_batch_size: 100
 ```
 
-The task executor arguments are passed as a <String, Object> map, new parameters should be registered via the [TaskExecutorArgumentsParser](/src/main/java/com/microsoft/lst_bench/util/TaskExecutorArgumentsParser.java) to ensure that only valid parameters are passed into the execution.
-An example for how task-specific arguments can be incorporated into the execution class, refer to the [DependentTaskExecutorArguments](/src/main/java/com/microsoft/lst_bench/task/custom/DependentTaskExecutor.java).
+The task executor arguments are passed as a <String, Object> map, new parameters should be registered via the [TaskExecutorArgumentsParser](/core/src/main/java/com/microsoft/lst_bench/util/TaskExecutorArgumentsParser.java) to ensure that only valid parameters are passed into the execution.
+An example for how task-specific arguments can be incorporated into the execution class, refer to the [DependentTaskExecutorArguments](/core/src/main/java/com/microsoft/lst_bench/task/custom/DependentTaskExecutor.java).
 
 ### Prepared Tasks
 
@@ -118,7 +118,7 @@ Once that is done, we can reference the sequence in the workload file:
 
 ## Session
 
-A _session_ refers to a sequence of tasks representing a logical unit of work or a user session, aligning with the concept of sessions in JDBC.
+A _session_ refers to a collection of tasks representing a logical unit of work or a user session, aligning with the concept of sessions in JDBC.
 
 For instance, the following snippet illustrates a sample session executing the `single_user_simple` task template declared earlier:
 
@@ -130,7 +130,26 @@ For instance, the following snippet illustrates a sample session executing the `
 
 If no endpoint is specified, the session is associated with a default target endpoint—the first connection declared in the connections YAML config file.
 
-Moreover, a session can also be defined using tasks sequences. For instance, the following snippet demonstrates a sample session that combines two sequences: one previously defined in the library and another inlined sequence using a `tasks` block. This session will execute a total of four `single_user_simple` tasks.
+Tasks within a session can be executed either concurrently or sequentially, based on workload requirements.
+For concurrent execution, each task must specify a start time relative to the beginning of the session, and the maximum number of tasks that can run in parallel should be defined at the session level.
+Note that tasks with defined start time cannot be mixed with those without in the same session.
+The following snippet demonstrates a session executing tasks concurrently:
+
+```yaml
+  - tasks:
+    - template_id: single_user_simple
+      permute_order: true
+      start: 0
+    - template_id: single_user_simple
+      permute_order: true
+      start: 10000
+    - template_id: single_user_simple
+      permute_order: true
+      start: 20000     
+    max_concurrency: 2
+```
+
+Additionally, a session can also be defined using tasks sequences. For instance, the following snippet demonstrates a sample session that combines two sequences: one previously defined in the library and another inlined sequence using a `tasks` block. This session will execute a total of four `single_user_simple` tasks.
 
 ```yaml
   - tasks_sequences:


### PR DESCRIPTION
This PR introduces the ability to execute tasks concurrently within a session, providing more flexibility in workload management.
For concurrent execution, each task must specify a start time relative to the beginning of the session, and the maximum number of tasks that can run in parallel should be defined at the session level.
The following snippet shows the definition of a session executing tasks concurrently:

```yaml
  - tasks:
    - template_id: single_user_simple
      permute_order: true
      start: 0
    - template_id: single_user_simple
      permute_order: true
      start: 10000
    - template_id: single_user_simple
      permute_order: true
      start: 20000     
    max_concurrency: 2
```
