### PR TITLE
Add Docker build and per-profile image tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+**/target
+.idea
+.vscode
+*.iml
+*.log
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM eclipse-temurin:17-jdk-jammy AS build
+
+WORKDIR /workspace
+
+COPY . .
+
+ARG MAVEN_PROFILES=""
+
+RUN if [ -n "${MAVEN_PROFILES}" ]; then \
+      ./mvnw -pl core -am package -P"${MAVEN_PROFILES}"; \
+    else \
+      ./mvnw -pl core -am package; \
+    fi
+
+FROM eclipse-temurin:17-jre-jammy
+
+ARG LST_BENCH_UID=10001
+ARG LST_BENCH_GID=10001
+
+RUN groupadd -g "${LST_BENCH_GID}" lstbench \
+    && useradd -r -u "${LST_BENCH_UID}" -g lstbench -m -d /opt/lst-bench lstbench
+
+WORKDIR /opt/lst-bench
+
+COPY --from=build /workspace/core/target/ /opt/lst-bench/core/target/
+COPY --from=build /workspace/launcher.sh /opt/lst-bench/launcher.sh
+
+RUN chmod +x /opt/lst-bench/launcher.sh \
+    && chown -R lstbench:lstbench /opt/lst-bench
+
+USER lstbench
+
+ENV LST_BENCH_HOME=/opt/lst-bench
+
+ENTRYPOINT ["/opt/lst-bench/launcher.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,78 @@
+IMAGE_REPO ?= ikyrannas/lst-bench
+DOCKER ?= docker
+
+PROFILES := base spark-jdbc spark-client trino-jdbc databricks-jdbc snowflake-jdbc microsoft-fabric-jdbc
+
+.PHONY: help
+help:
+	@echo "Targets:"
+	@echo "  build-<profile>  Build image for profile (e.g., build-spark-jdbc)"
+	@echo "  push-<profile>   Push image for profile (e.g., push-spark-jdbc)"
+	@echo "  build-all        Build all profile images"
+	@echo "  push-all         Push all profile images"
+	@echo ""
+	@echo "Vars:"
+	@echo "  IMAGE_REPO=ikyrannas/lst-bench  Docker image repo"
+	@echo "  DOCKER=docker                  Docker binary"
+
+.PHONY: build-all
+build-all: $(addprefix build-,$(PROFILES))
+
+.PHONY: push-all
+push-all: $(addprefix push-,$(PROFILES))
+
+.PHONY: build-base
+build-base:
+	$(DOCKER) build -t $(IMAGE_REPO):base .
+
+.PHONY: build-spark-jdbc
+build-spark-jdbc:
+	$(DOCKER) build -t $(IMAGE_REPO):spark-jdbc --build-arg MAVEN_PROFILES=spark-jdbc .
+
+.PHONY: build-spark-client
+build-spark-client:
+	$(DOCKER) build -t $(IMAGE_REPO):spark-client --build-arg MAVEN_PROFILES=spark-client .
+
+.PHONY: build-trino-jdbc
+build-trino-jdbc:
+	$(DOCKER) build -t $(IMAGE_REPO):trino-jdbc --build-arg MAVEN_PROFILES=trino-jdbc .
+
+.PHONY: build-databricks-jdbc
+build-databricks-jdbc:
+	$(DOCKER) build -t $(IMAGE_REPO):databricks-jdbc --build-arg MAVEN_PROFILES=databricks-jdbc .
+
+.PHONY: build-snowflake-jdbc
+build-snowflake-jdbc:
+	$(DOCKER) build -t $(IMAGE_REPO):snowflake-jdbc --build-arg MAVEN_PROFILES=snowflake-jdbc .
+
+.PHONY: build-microsoft-fabric-jdbc
+build-microsoft-fabric-jdbc:
+	$(DOCKER) build -t $(IMAGE_REPO):microsoft-fabric-jdbc --build-arg MAVEN_PROFILES=microsoft-fabric-jdbc .
+
+.PHONY: push-base
+push-base:
+	$(DOCKER) push $(IMAGE_REPO):base
+
+.PHONY: push-spark-jdbc
+push-spark-jdbc:
+	$(DOCKER) push $(IMAGE_REPO):spark-jdbc
+
+.PHONY: push-spark-client
+push-spark-client:
+	$(DOCKER) push $(IMAGE_REPO):spark-client
+
+.PHONY: push-trino-jdbc
+push-trino-jdbc:
+	$(DOCKER) push $(IMAGE_REPO):trino-jdbc
+
+.PHONY: push-databricks-jdbc
+push-databricks-jdbc:
+	$(DOCKER) push $(IMAGE_REPO):databricks-jdbc
+
+.PHONY: push-snowflake-jdbc
+push-snowflake-jdbc:
+	$(DOCKER) push $(IMAGE_REPO):snowflake-jdbc
+
+.PHONY: push-microsoft-fabric-jdbc
+push-microsoft-fabric-jdbc:
+	$(DOCKER) push $(IMAGE_REPO):microsoft-fabric-jdbc

--- a/README.md
+++ b/README.md
@@ -77,6 +77,41 @@ usage: ./launcher.sh -c <arg> -e <arg> -l <arg> -t <arg> -w <arg>
                                  the workload definition
 ```
 
+### Run with Docker
+
+Build the image:
+
+```bash
+docker build -t lst-bench:latest .
+```
+
+If you are connecting to a Spark Thrift Server via JDBC, build with the Spark JDBC profile so the Hive driver is included:
+
+```bash
+docker build -t lst-bench:latest --build-arg MAVEN_PROFILES=spark-jdbc .
+```
+
+Prepare your configuration files (YAML) in a local directory, for example `./config`:
+
+```bash
+mkdir -p config
+```
+
+Place connections.yaml, experiment.yaml, library.yaml, telemetry.yaml, workload.yaml there
+
+Run the container and mount the config directory:
+
+```bash
+docker run --rm \
+  -v "$PWD/config":/work/config:ro \
+  lst-bench:latest:latest \
+  -c /work/config/connections.yaml \
+  -e /work/config/experiment.yaml \
+  -l /work/config/library.yaml \
+  -t /work/config/telemetry.yaml \
+  -w /work/config/workload.yaml
+```
+
 ## Configuration Files
 The configuration files used in LST-Bench are YAML files. 
 


### PR DESCRIPTION
## Summary
This PR adds a production-ready Docker build for LST-Bench and documentation to streamline local usage and Docker Hub publishing. It also introduces a Makefile that builds/pushes per-profile images so the correct JDBC drivers are included.

## Changes
- Add multi-stage `Dockerfile` with non-root runtime and optional Maven profile support (`MAVEN_PROFILES`).
- Add `.dockerignore` to keep build context lean.
- Add `Makefile` with `build-<profile>`/`push-<profile>` targets and `build-all`/`push-all`.
- Update `README.md` with Docker build/run instructions and Spark Thrift example.

## Motivation / Context
Running LST-Bench from Docker makes it easier to:
- Standardize environments across machines.
- Ship the right JDBC driver set per engine.
These changes reduce setup time.

## How to Test

### Dockerhub image

I have already built and pushed the image to my Dockerhub repo for convenience.

1) Run with your configs:
```bash
docker run --rm \
  -v "$PWD/config":/work/config:ro \
  ikyrannas/lst-bench:spark-jdbc \
  -c /work/config/connections.yaml \
  -e /work/config/experiment.yaml \
  -l /work/config/library.yaml \
  -t /work/config/telemetry.yaml \
  -w /work/config/workload.yaml
```

### Local build

1) Build a profile image:
```bash
docker build -t lst-bench:spark-jdbc --build-arg MAVEN_PROFILES=spark-jdbc .
```

2) Run with your configs:
```bash
docker run --rm \
  -v "$PWD/config":/work/config:ro \
  lst-bench:spark-jdbc \
  -c /work/config/connections.yaml \
  -e /work/config/experiment.yaml \
  -l /work/config/library.yaml \
  -t /work/config/telemetry.yaml \
  -w /work/config/workload.yaml
```

## Notes
- The Makefile provides per-profile tags (e.g., `spark-jdbc`, `trino-jdbc`, etc.) to ensure the correct JDBC driver set is included.

## Checklist
- [ ] README updated
- [ ] No breaking changes
- [ ] Tests not required / not applicable for README & build tooling
